### PR TITLE
Scrub configured paths before printing, and list the new config keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to codex-claude-transfer are documented here.
 
+## [Unreleased]
+
+### Security / hardening
+- **Saved config values can no longer carry terminal escape sequences.**
+  `cct skill show` printed the configured store directory — and the bundle
+  paths built from it — without the scrubbing every other value gets, so a
+  hand-edited or generated `config.json` could inject ANSI/OSC sequences into
+  that output (SEC-10). It is scrubbed now, and `cct config set` rejects
+  control characters in `repo-sync-dir` and `repo-sync-recipient` outright, so
+  the value never gets stored in the first place.
+
+### Fixed
+- `cct config` help now lists `repo-sync-repo` and `repo-sync-dir`, which
+  v1.7.0 added to the settable keys but not to the usage text.
+
 ## [1.7.0] - 2026-08-02
 
 ### Added

--- a/internal/cli/config_cmd.go
+++ b/internal/cli/config_cmd.go
@@ -47,7 +47,8 @@ const configUsage = `usage: cct config <list | get <key> | set <key> <value> | p
   path              print the config file location
 
 keys: tool (codex|claude), codex-home, claude-home, port,
-      repo-sync (plain|encrypted), repo-sync-recipient (age1...)
+      repo-sync (plain|encrypted), repo-sync-recipient (age1...),
+      repo-sync-repo (<git-url>), repo-sync-dir (<path>)
 These are just defaults; an explicit flag always wins.`
 
 // runConfig manages cct's small set of saved user defaults.

--- a/internal/cli/skill_cmd.go
+++ b/internal/cli/skill_cmd.go
@@ -181,7 +181,10 @@ func runSkillShow(f commonFlags, stdout, stderr io.Writer) int {
 	if ref.Recipient != "" {
 		fmt.Fprintf(stdout, "  recipient   %s\n", safeTerminal(ref.Recipient))
 	}
-	fmt.Fprintf(stdout, "  clone       %s", storeDir)
+	// storeDir comes from local config rather than the repo, but a config file
+	// can be hand-edited or generated, and every other printer here scrubs, so
+	// it is scrubbed too. os.Stat still uses the unmodified path.
+	fmt.Fprintf(stdout, "  clone       %s", safeTerminal(storeDir))
 	if _, serr := os.Stat(storeDir); serr == nil {
 		fmt.Fprintln(stdout, "  (present)")
 	} else {
@@ -189,7 +192,7 @@ func runSkillShow(f commonFlags, stdout, stderr io.Writer) int {
 	}
 	fmt.Fprintln(stdout)
 	for _, tool := range []string{"claude", "codex"} {
-		fmt.Fprintf(stdout, "  %-6s bundle  %s\n", tool, skill.BundlePathIn(storeDir, ref, tool))
+		fmt.Fprintf(stdout, "  %-6s bundle  %s\n", tool, safeTerminal(skill.BundlePathIn(storeDir, ref, tool)))
 	}
 	fmt.Fprintln(stdout)
 	fmt.Fprintln(stdout, "That repo URL comes from this repository, not from you. If you did not set it")

--- a/internal/cli/skill_cmd_test.go
+++ b/internal/cli/skill_cmd_test.go
@@ -189,6 +189,44 @@ func TestSkillShowRejectsHostileReference(t *testing.T) {
 	}
 }
 
+// `cct config set` refuses control characters, but a config file can also be
+// hand-edited or written by another tool, so nothing it holds may reach the
+// terminal unscrubbed.
+func TestSkillShowScrubsTheConfiguredStoreDir(t *testing.T) {
+	tmp := t.TempDir()
+	cfgDir := filepath.Join(tmp, "cfg")
+	if err := os.MkdirAll(cfgDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// A raw control byte is invalid JSON, so the file carries the escapes that
+	// Load decodes back into real ones.
+	cfg := `{"repo_sync_dir":"/tmp/store\u001b]0;pwned\u0007"}`
+	if err := os.WriteFile(filepath.Join(cfgDir, "config.json"), []byte(cfg), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CCT_CONFIG_DIR", cfgDir)
+
+	proj := filepath.Join(tmp, "proj")
+	if err := os.MkdirAll(filepath.Join(proj, skill.RefSubdir), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ref := `{"version":1,"repo":"git@github.com:me/s.git","project":"proj","path":"projects/proj","encryption":"plain"}`
+	if err := os.WriteFile(skill.RefPath(proj), []byte(ref), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, e, code := run("skill", "show", "--project", proj)
+	if code != 0 {
+		t.Fatalf("show exit=%d %s", code, e)
+	}
+	if strings.ContainsAny(out, "\x1b\a") {
+		t.Fatalf("an escape sequence from the config reached stdout:\n%q", out)
+	}
+	if !strings.Contains(out, "/tmp/store") {
+		t.Fatalf("the path itself should still be shown:\n%s", out)
+	}
+}
+
 // TestSkillFlow runs the exact command sequence the skill documents — export
 // into .cct/, then restore into another machine's home from another path — so
 // the instructions cannot silently drift away from the CLI.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -137,6 +137,9 @@ func (c *Config) Set(key, value string) error {
 		}
 		c.RepoSyncRepo = value
 	case "repo-sync-dir":
+		if i := strings.IndexFunc(value, isControl); i >= 0 {
+			return fmt.Errorf("the path contains a control character at byte %d", i)
+		}
 		c.RepoSyncDir = value
 	default:
 		return fmt.Errorf("unknown config key %q (known: %v)", key, Keys)
@@ -171,6 +174,13 @@ func (c Config) Get(key string) (string, error) {
 	}
 }
 
+// isControl reports the C0/C1 control characters. A saved value can end up in
+// terminal output, so a config file is not allowed to carry escape sequences —
+// no legitimate path or key contains one.
+func isControl(r rune) bool {
+	return r < 0x20 || r == 0x7f || (r >= 0x80 && r <= 0x9f)
+}
+
 // validRecipient rejects anything that is obviously not an age recipient, so a
 // typo (or a pasted private key) is caught here rather than by age much later.
 // It deliberately does not try to validate the key material itself.
@@ -184,10 +194,8 @@ func validRecipient(value string) error {
 	if len(value) > 1024 {
 		return fmt.Errorf("recipient is too long (%d bytes)", len(value))
 	}
-	for _, r := range value {
-		if r == '\n' || r == '\r' || r == 0 {
-			return fmt.Errorf("recipient contains a line break or NUL byte")
-		}
+	if i := strings.IndexFunc(value, isControl); i >= 0 {
+		return fmt.Errorf("recipient contains a control character at byte %d", i)
 	}
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -106,6 +106,21 @@ func TestRepoSyncKeys(t *testing.T) {
 	if err := c.Set("repo-sync-recipient", "not-a-key"); err == nil {
 		t.Fatal("expected error for a recipient that is not an age key")
 	}
+	// A saved value can reach the terminal, so escape sequences are refused at
+	// the point they would be stored.
+	if err := c.Set("repo-sync-dir", "~/store\x1b]0;pwned\a"); err == nil {
+		t.Fatal("a path with an escape sequence was accepted")
+	}
+	if err := c.Set("repo-sync-dir", "~/store"); err != nil {
+		t.Fatalf("an ordinary path was refused: %v", err)
+	}
+	if err := c.Set("repo-sync-repo", "https://h/r.git\nrm -rf /"); err == nil {
+		t.Fatal("a multi-line repo URL was accepted")
+	}
+	if err := c.Set("repo-sync-repo", "ext::sh -c evil"); err == nil {
+		t.Fatal("a remote-helper transport was accepted")
+	}
+
 	// Clearing works for both.
 	if err := c.Set("repo-sync", ""); err != nil || c.RepoSync != "" {
 		t.Fatalf("clear repo-sync: %v (%q)", err, c.RepoSync)


### PR DESCRIPTION
Addresses both findings from the Copilot review of #17.

**1. `skill show` printed `storeDir` unscrubbed (medium).** Valid, though the stated reason is only half right: `storeDir` comes from *local* config (`repo-sync-dir`), not from the repository, so it is not reachable through a malicious pull request the way the reference file is. It is still a real inconsistency — `cct config list` already scrubs that same value, `config set repo-sync-dir` validated nothing, and the command's promise is that nothing reaches the terminal unfiltered.

Fixed at both ends:
- `safeTerminal` on the clone line **and** on the bundle paths built from it (the review only named the clone line; the same value leaks through `BundlePathIn`). `os.Stat` still uses the unmodified path.
- `cct config set` now rejects control characters in `repo-sync-dir` and `repo-sync-recipient`, so the value is never stored. `validRecipient`'s ad-hoc `\n`/`\r`/NUL check became the same shared `isControl` predicate.

**2. `cct config` help missing the new keys (low).** Correct oversight — `repo-sync-repo` and `repo-sync-dir` are listed now.

**Tests**: `TestSkillShowScrubsTheConfiguredStoreDir` writes a `config.json` containing `\u001b]0;pwned\u0007` by hand (the path a validated `config set` no longer allows) and asserts no escape byte reaches stdout while the readable path still does. Verified it fails when the scrub is reverted. `TestRepoSyncKeys` covers the new refusals.

`go vet`, `gofmt`, and the full suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
