### PR TITLE
Rehearsable release, native macOS smoke test, offline dependency proof

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,26 +3,75 @@ name: Release
 # Builds cross-platform binaries and attaches them to a GitHub Release when you
 # push a version tag like v0.1.0. This does not publish anywhere else, does not
 # touch any server, and does not run automatically on normal pushes.
+#
+# It can also be started by hand (workflow_dispatch) as a DRY RUN: everything up
+# to and including the release assembly runs — build, packaged-artifact smoke
+# tests, the offline dependency-archive proof, SBOM, checksums, archive layout
+# and permission checks — but no GitHub Release is created. That is how changes
+# to this file get tested without burning a version number. Signing and
+# attestation are skipped by default in a dry run because both publish a public
+# record; tick `sign` to exercise them too.
+#
+# Third-party actions are pinned to a commit SHA (the tag is in the trailing
+# comment) so a moved tag cannot change what runs in a release build.
 
 on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      sign:
+        description: "Dry run: also run Sigstore signing and build attestation (publishes a public transparency-log record)"
+        type: boolean
+        default: false
 
 permissions:
   contents: read
 
 jobs:
+  meta:
+    name: Resolve version
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      version: ${{ steps.v.outputs.version }}
+      is_release: ${{ steps.v.outputs.is_release }}
+      sign: ${{ steps.v.outputs.sign }}
+    steps:
+      # A tag push releases under its own name; a manual run builds a clearly
+      # marked dry-run version so no artifact can be mistaken for a release.
+      - name: Decide version and mode
+        id: v
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${GITHUB_REF_TYPE}" = "tag" ] && [ "${GITHUB_REF_NAME#v}" != "${GITHUB_REF_NAME}" ]; then
+            echo "version=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+            echo "is_release=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=v0.0.0-dryrun-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+            echo "is_release=false" >> "$GITHUB_OUTPUT"
+          fi
+          echo "sign=${{ inputs.sign == true }}" >> "$GITHUB_OUTPUT"
+
+      - name: Summarize
+        shell: bash
+        run: |
+          echo "version=${{ steps.v.outputs.version }}"
+          echo "is_release=${{ steps.v.outputs.is_release }}"
+
   dependencies:
     name: Package Go dependencies
+    needs: meta
     runs-on: ubuntu-latest
-    timeout-minutes: 360
+    timeout-minutes: 45
     steps:
       - name: Check out code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version-file: go.mod
           check-latest: true
@@ -32,7 +81,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          version="${GITHUB_REF_NAME#v}"
+          version="${{ needs.meta.outputs.version }}"
+          version="${version#v}"
           export GOMODCACHE="${PWD}/go-mod"
           go mod download -modcacherw
           go mod verify
@@ -41,30 +91,56 @@ jobs:
             -I 'xz -T0 -9' -cf \
             "dist/codex-claude-transfer-${version}-deps.tar.xz" go-mod
 
+      # Prove the archive is usable, not merely present: unpack it somewhere
+      # else, point Go at it, and build with the network refused. GOPROXY=off
+      # makes any attempt to fetch a module a hard error, and GOTOOLCHAIN=local
+      # stops Go from downloading a different toolchain instead.
+      - name: Build offline from the packaged dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${{ needs.meta.outputs.version }}"
+          version="${version#v}"
+          offline="$(mktemp -d)"
+          tar -xf "dist/codex-claude-transfer-${version}-deps.tar.xz" -C "$offline"
+          test -d "$offline/go-mod" || { echo "the archive has no go-mod root" >&2; exit 1; }
+          rm -rf "${PWD}/go-mod"
+          env -i PATH="$PATH" HOME="$HOME" \
+            GOMODCACHE="$offline/go-mod" \
+            GOFLAGS=-mod=mod \
+            GOPROXY=off \
+            GOSUMDB=off \
+            GOTOOLCHAIN=local \
+            go build -o "$offline/cct" ./cmd/cct
+          "$offline/cct" version
+          rm -rf "$offline"
+
       - name: Upload dependency artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: codex-claude-transfer-go-dependencies
           path: dist/*-deps.tar.xz
 
   build:
     name: Build ${{ matrix.goos }}/${{ matrix.goarch }}
+    needs: meta
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
         include:
-          - { goos: linux,   goarch: amd64 }
-          - { goos: linux,   goarch: arm64 }
-          - { goos: darwin,  goarch: amd64 }
-          - { goos: darwin,  goarch: arm64 }
+          - { goos: linux, goarch: amd64 }
+          - { goos: linux, goarch: arm64 }
+          - { goos: darwin, goarch: amd64 }
+          - { goos: darwin, goarch: arm64 }
           - { goos: windows, goarch: amd64 }
     steps:
       - name: Check out code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version-file: go.mod
           check-latest: true
@@ -76,7 +152,7 @@ jobs:
           CGO_ENABLED: "0"
         shell: bash
         run: |
-          version="${GITHUB_REF_NAME}"
+          version="${{ needs.meta.outputs.version }}"
           name="cct"
           ext=""
           if [ "$GOOS" = "windows" ]; then ext=".exe"; fi
@@ -86,8 +162,39 @@ jobs:
           cp README.md docs/safety.md "$outdir/" 2>/dev/null || true
           ( cd dist && tar -czf "${name}_${version}_${GOOS}_${GOARCH}.tar.gz" "$(basename "$outdir")" )
 
+      # The archive is what users download, so check its shape here rather than
+      # discovering a missing doc or a non-executable binary after publishing.
+      - name: Check the archive's contents and permissions
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${{ needs.meta.outputs.version }}"
+          dir="cct_${version}_${{ matrix.goos }}_${{ matrix.goarch }}"
+          archive="dist/${dir}.tar.gz"
+          bin="cct"
+          if [ "${{ matrix.goos }}" = "windows" ]; then bin="cct.exe"; fi
+          listing="$(tar -tzf "$archive")"
+          echo "$listing"
+          for want in "$dir/$bin" "$dir/README.md" "$dir/safety.md"; do
+            printf '%s\n' "$listing" | grep -qx "$want" || { echo "missing from the archive: $want" >&2; exit 1; }
+          done
+          # Nothing outside the single top-level directory, so unpacking cannot
+          # scatter files into the current folder.
+          bad="$(printf '%s\n' "$listing" | grep -v "^${dir}\(/\|$\)" || true)"
+          if [ -n "$bad" ]; then echo "entries outside ${dir}/:" >&2; echo "$bad" >&2; exit 1; fi
+          modes="$(tar -tvzf "$archive")"
+          echo "$modes"
+          binmode="$(printf '%s\n' "$modes" | awk -v f="$dir/$bin" '$NF == f {print $1}')"
+          case "$binmode" in
+            -rwxr-xr-x) ;;
+            *) echo "unexpected mode for $bin: $binmode (want -rwxr-xr-x)" >&2; exit 1 ;;
+          esac
+          if printf '%s\n' "$modes" | awk '{print $1}' | grep -q '^.....w\|^........w'; then
+            echo "an archive entry is group- or world-writable" >&2; exit 1
+          fi
+
       - name: Upload build artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: cct_${{ matrix.goos }}_${{ matrix.goarch }}
           path: dist/*.tar.gz
@@ -95,19 +202,21 @@ jobs:
   smoke:
     name: Smoke-test ${{ matrix.goos }}/${{ matrix.goarch }} artifact
     needs: build
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
         include:
           - { goos: linux, goarch: amd64, os: ubuntu-latest }
+          - { goos: darwin, goarch: arm64, os: macos-latest }
           - { goos: windows, goarch: amd64, os: windows-latest }
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Download the built artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: cct_${{ matrix.goos }}_${{ matrix.goarch }}
           path: dist
@@ -123,33 +232,31 @@ jobs:
           echo "Testing packaged binary: $bin"
           bash scripts/smoke-artifact.sh "$bin"
 
-  release:
-    name: Publish release
-    needs: [build, smoke, dependencies]
+  assemble:
+    name: Assemble release files
+    needs: [meta, build, smoke, dependencies]
     runs-on: ubuntu-latest
-    # Provenance: checksums + SBOM + GitHub artifact attestation + a
-    # Sigstore-signed checksum file, so every release asset is verifiable.
-    # See "Verifying a release" in docs/internals.md.
+    timeout-minutes: 30
     permissions:
-      contents: write      # create the release and upload assets
-      id-token: write      # keyless (OIDC) signing via Sigstore
-      attestations: write  # GitHub artifact attestations
+      contents: read
+      id-token: write # keyless (OIDC) Sigstore signing
+      attestations: write # GitHub artifact attestations
     steps:
       - name: Check out code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Download artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: dist
           merge-multiple: true
 
       - name: Generate SBOM (SPDX)
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
         with:
           path: .
           format: spdx-json
-          output-file: dist/cct_${{ github.ref_name }}_sbom.spdx.json
+          output-file: dist/cct_${{ needs.meta.outputs.version }}_sbom.spdx.json
           upload-artifact: false
           upload-release-assets: false
 
@@ -160,31 +267,94 @@ jobs:
           sha256sum *.tar.gz *.tar.xz *_sbom.spdx.json > SHA256SUMS.txt
           cat SHA256SUMS.txt
 
+      - name: Check the release file set
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${{ needs.meta.outputs.version }}"
+          cd dist
+          for want in \
+            "cct_${version}_linux_amd64.tar.gz" \
+            "cct_${version}_linux_arm64.tar.gz" \
+            "cct_${version}_darwin_amd64.tar.gz" \
+            "cct_${version}_darwin_arm64.tar.gz" \
+            "cct_${version}_windows_amd64.tar.gz" \
+            "cct_${version}_sbom.spdx.json" \
+            "SHA256SUMS.txt"; do
+            test -f "$want" || { echo "missing release file: $want" >&2; exit 1; }
+          done
+          ls -1 codex-claude-transfer-*-deps.tar.xz > /dev/null
+          sha256sum -c SHA256SUMS.txt
+
+      # Provenance: a Sigstore-signed checksum file plus a GitHub artifact
+      # attestation, so every published asset is verifiable. Both write a public
+      # record, so a dry run only does it when explicitly asked.
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        if: needs.meta.outputs.is_release == 'true' || needs.meta.outputs.sign == 'true'
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
 
       - name: Sign checksum file (Sigstore keyless)
+        if: needs.meta.outputs.is_release == 'true' || needs.meta.outputs.sign == 'true'
         shell: bash
         run: |
           cosign sign-blob --yes \
             --bundle dist/SHA256SUMS.txt.sigstore.json \
             dist/SHA256SUMS.txt
+          cosign verify-blob \
+            --bundle dist/SHA256SUMS.txt.sigstore.json \
+            --certificate-identity-regexp "^https://github.com/${GITHUB_REPOSITORY}/" \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            dist/SHA256SUMS.txt
 
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@v4
+        if: needs.meta.outputs.is_release == 'true' || needs.meta.outputs.sign == 'true'
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4
         with:
           subject-path: |
             dist/*.tar.gz
             dist/*.tar.xz
             dist/SHA256SUMS.txt
 
+      - name: Upload the assembled release files
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: release-files
+          path: dist/*
+
+      - name: Dry-run summary
+        if: needs.meta.outputs.is_release != 'true'
+        shell: bash
+        run: |
+          {
+            echo "### Release dry run"
+            echo
+            echo "Built, smoke-tested and assembled \`${{ needs.meta.outputs.version }}\`."
+            echo "No GitHub Release was created. Signing/attestation: \`${{ needs.meta.outputs.sign }}\`."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  publish:
+    name: Publish release
+    needs: [meta, assemble]
+    # Only a real version tag publishes. A manual dry run stops after assemble.
+    if: needs.meta.outputs.is_release == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: write # create the release and upload assets
+    steps:
+      - name: Download the assembled release files
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: release-files
+          path: dist
+
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
           files: |
             dist/*.tar.gz
             dist/*.tar.xz
             dist/SHA256SUMS.txt
             dist/SHA256SUMS.txt.sigstore.json
-            dist/cct_${{ github.ref_name }}_sbom.spdx.json
+            dist/cct_${{ needs.meta.outputs.version }}_sbom.spdx.json
           generate_release_notes: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,43 @@
 
 All notable changes to codex-claude-transfer are documented here.
 
+## [Unreleased]
+
+### Changed
+- **The release workflow can be rehearsed.** It now also runs on
+  `workflow_dispatch` as a dry run: build, packaged-artifact smoke tests, the
+  dependency-archive check, SBOM, checksums and the release-file check all run
+  under a `v0.0.0-dryrun-<sha>` version, and the assembled files are uploaded as
+  a workflow artifact — but no GitHub Release is created. Publishing is a
+  separate job gated on a real version tag. Signing and attestation are skipped
+  in a dry run unless the `sign` input is set, because both write to a public
+  transparency log; when they do run, the signature is verified in place with
+  `cosign verify-blob`.
+- **The packaged binary is now smoke-tested on macOS too** (darwin/arm64),
+  alongside Linux and Windows, and the smoke test itself covers much more: the
+  `skill` commands including a refused `ext::` reference, a cwd round trip
+  (import with `--map-cwd-here`, then find the session again with
+  `--project .`), unicode project paths, a project under `$TMPDIR` — the
+  symlinked `/var` → `/private/var` path that broke a test on macOS earlier —
+  file permissions, and relocate + undo.
+- **The Gentoo dependency archive is proven offline, not just produced.** After
+  packaging, the release unpacks it elsewhere and builds `cct` from it with
+  `GOPROXY=off`, `GOSUMDB=off` and `GOTOOLCHAIN=local`, so a missing module
+  fails the release instead of the packager.
+- **Release workflow hardening**: third-party actions are pinned to commit SHAs
+  (the tag stays in a comment), the 360-minute job timeout is replaced by 10–45
+  minutes per job, and each archive is checked for its expected contents, a
+  single top-level directory, an executable binary, and no group- or
+  world-writable entries.
+
+### Added
+- A recording tape for the `cct-session-sync` workflow
+  (`demo/recording/16-skill.tape` plus its `skill` scenario in `prep.sh`):
+  install the skill, point the project at a private session store, commit the
+  reference, export into the store, then clone on a second machine and restore
+  with `import --merge --map-cwd-here`. It uses synthetic sessions and local
+  bare repositories only. The GIF itself is not rendered yet.
+
 ## [1.7.1] - 2026-08-02
 
 ### Security / hardening

--- a/demo/recording/16-skill.tape
+++ b/demo/recording/16-skill.tape
@@ -1,0 +1,107 @@
+Output "16-skill.gif"
+
+Set Shell "bash"
+Set FontFamily "DejaVu Sans Mono"
+Set FontSize 18
+Set Width 1280
+Set Height 820
+Set Padding 24
+Set Theme "Catppuccin Mocha"
+Set TypingSpeed 40ms
+
+Hide
+Type "export PATH=$HOME/.local/bin:$PATH" Enter
+Type "export CLAUDE_HOME=$HOME/cct-rec/skill/claude-a" Enter
+Type "export CCT_CONFIG_DIR=$HOME/cct-rec/skill/cfg" Enter
+Type "cd $HOME/projects/todo-api" Enter
+Type "export PS1='$ '" Enter
+Type "clear" Enter
+Show
+
+Sleep 800ms
+Type "#  Teach the agent the workflow — one file in your Claude Code home"
+Enter
+Sleep 600ms
+Type "cct skill install"
+Sleep 300ms
+Enter
+Sleep 3000ms
+
+Type "#  Chat history goes to a PRIVATE store repo, not into this project"
+Enter
+Sleep 600ms
+Type "cct config set repo-sync-repo ~/cct-rec/skill/sessions.git"
+Sleep 300ms
+Enter
+Sleep 1500ms
+
+Type "cct skill init"
+Sleep 300ms
+Enter
+Sleep 3000ms
+
+Type "#  That is all this repo carries — a reference, no transcripts"
+Enter
+Sleep 600ms
+Type "cat .cct/sessions.json"
+Sleep 300ms
+Enter
+Sleep 3500ms
+
+Type "git add .cct && git commit -qm 'Point at the session store' && git push -q"
+Sleep 300ms
+Enter
+Sleep 1500ms
+
+Type "#  Save this project's sessions into the store, then commit them there"
+Enter
+Sleep 600ms
+Type "cct export --project . --tool claude -o ~/cct-store/projects/todo-api/claude/claude-all.codexbundle"
+Sleep 300ms
+Enter
+Sleep 3000ms
+
+Type "git -C ~/cct-store add -A && git -C ~/cct-store commit -qm 'Update todo-api sessions' && git -C ~/cct-store push -q"
+Sleep 300ms
+Enter
+Sleep 2000ms
+
+Type "clear"
+Enter
+Sleep 500ms
+
+Type "#  ── Second machine: clone the project, and it knows where its chats are"
+Enter
+Sleep 800ms
+Hide
+Type "export CLAUDE_HOME=$HOME/cct-rec/skill/claude-b" Enter
+Type "clear" Enter
+Show
+Type "git clone -q ~/cct-rec/skill/todo-api.git ~/projects/todo-api-clone && cd ~/projects/todo-api-clone"
+Sleep 300ms
+Enter
+Sleep 1500ms
+
+Type "cct skill show"
+Sleep 300ms
+Enter
+Sleep 4000ms
+
+Type "git clone -q ~/cct-rec/skill/sessions.git ~/cct-store-b"
+Sleep 300ms
+Enter
+Sleep 1500ms
+
+Type "cct import ~/cct-store-b/projects/todo-api/claude/claude-all.codexbundle --merge --map-cwd-here"
+Sleep 300ms
+Enter
+Sleep 4000ms
+
+Type "cct list --tool claude"
+Sleep 300ms
+Enter
+Sleep 4000ms
+
+Type "#  Same chats, new machine, new path — and the code repo stayed clean."
+Enter
+Sleep 2500ms

--- a/demo/recording/prep.sh
+++ b/demo/recording/prep.sh
@@ -72,7 +72,7 @@ case "$scenario" in
       git -c user.email=demo@example.com -c user.name=demo add -A
       git -c user.email=demo@example.com -c user.name=demo commit -qm "initial skeleton"
       git remote add origin "$REC/gitdemo/bare-remote"
-      git push -q origin HEAD:main
+      git push -q -u origin HEAD:main
     )
     mkdir -p "$REC/gitsrc/codex-home"
     python3 - "$REC/gitsrc/codex-home" "$REC/gitdemo/work" <<'PY'
@@ -121,6 +121,70 @@ PY
     # time runs days ahead of its newest content timestamp.
     f=$(find "$REC/laptop/codex-home/sessions" -name '*b2c3d4e5*.jsonl' | head -1)
     touch -d "2026-06-20T23:00:00" "$f"
+    ;;
+  skill)
+    # The cct-session-sync scenario: a project repo, fake Claude Code sessions
+    # for it, and a "private session store" that is just another local repo.
+    # Every repository here is a local bare repo — nothing leaves this machine.
+    gitcfg=(-c user.email=demo@example.com -c user.name=demo)
+    rm -rf "$REC/skill" "$HOME/cct-store" "$HOME/cct-store-b" "$HOME/projects/todo-api-clone"
+    mkdir -p "$REC/skill"
+
+    # The project itself, with a bare remote so the second machine can clone it.
+    rm -rf "$HOME/projects/todo-api"; mkdir -p "$HOME/projects/todo-api"
+    (
+      cd "$REC/skill" && git init -q --bare todo-api.git
+      # The bare repos default to a master HEAD; point them at the branch that
+      # is actually pushed, so a clone checks something out.
+      git -C "$REC/skill/todo-api.git" symbolic-ref HEAD refs/heads/main
+      cd "$HOME/projects/todo-api"
+      git init -q && git symbolic-ref HEAD refs/heads/main
+      echo "# todo-api — a small REST service" > README.md
+      git "${gitcfg[@]}" add -A && git "${gitcfg[@]}" commit -qm "initial skeleton"
+      git remote add origin "$REC/skill/todo-api.git"
+      git push -q -u origin HEAD:main
+    )
+
+    # The private session store: a bare repo, already cloned on this machine.
+    ( cd "$REC/skill" && git init -q --bare sessions.git )
+    git -C "$REC/skill/sessions.git" symbolic-ref HEAD refs/heads/main
+    git clone -q "$REC/skill/sessions.git" "$HOME/cct-store"
+    (
+      cd "$HOME/cct-store"
+      git symbolic-ref HEAD refs/heads/main
+      echo "# Private session store (demo)" > README.md
+      git "${gitcfg[@]}" add -A && git "${gitcfg[@]}" commit -qm "start the store"
+      git push -q -u origin HEAD:main
+    )
+
+    # Fake Claude Code transcripts for the project — synthetic text only.
+    python3 - "$REC/skill/claude-a" "$HOME/projects/todo-api" <<'PY'
+import json, os, sys
+home, cwd = sys.argv[1], sys.argv[2]
+encoded = "".join(c if (c.isascii() and (c.isalnum() or c == "-")) else "-" for c in cwd)
+d = os.path.join(home, "projects", encoded)
+os.makedirs(d, exist_ok=True)
+chats = [
+    ("11111111-2222-3333-4444-555555555555", "2026-06-14T09:12:00Z",
+     "Sketch the REST handlers for the todo endpoints."),
+    ("22222222-3333-4444-5555-666666666666", "2026-06-15T16:40:00Z",
+     "The list endpoint should paginate — 20 per page, cursor based."),
+    ("33333333-4444-5555-6666-777777777777", "2026-06-16T11:05:00Z",
+     "Add a migration for the due_date column and backfill it."),
+]
+for sid, ts, first in chats:
+    p = os.path.join(d, sid + ".jsonl")
+    with open(p, "w") as fh:
+        fh.write(json.dumps({"type": "user", "uuid": sid, "sessionId": sid, "cwd": cwd,
+                             "timestamp": ts,
+                             "message": {"role": "user", "content": first}}) + "\n")
+        fh.write(json.dumps({"type": "assistant", "uuid": sid + "-a", "sessionId": sid,
+                             "cwd": cwd, "timestamp": ts,
+                             "message": {"role": "assistant",
+                                         "content": "Sure — here is the plan."}}) + "\n")
+PY
+    # The second machine starts with an empty Claude home.
+    mkdir -p "$REC/skill/claude-b"
     ;;
   *)
     echo "unknown scenario: $scenario" >&2; exit 2;;

--- a/demo/recording/record.sh
+++ b/demo/recording/record.sh
@@ -43,7 +43,7 @@ for f in prep.sh \
          01-overview.tape 02-sync.tape 03-claude-handoff.tape 04-encryption.tape \
          05-conflicts-remap.tape 06-export-filters.tape 07-git-handoff.tape 08-cli-ui.tape \
          09-compressed.tape 11-search.tape 12-secrets.tape 13-markdown.tape \
-         14-repair-times.tape 15-sync.tape; do
+         14-repair-times.tape 15-sync.tape 16-skill.tape; do
   tr -d '\r' < "$REPO/demo/recording/$f" > "$REC/$f"
 done
 
@@ -72,6 +72,7 @@ render 12-secrets.tape         secrets
 render 13-markdown.tape        base
 render 14-repair-times.tape    stale
 render 15-sync.tape            base
+render 16-skill.tape           skill
 
 # --- 6. Copy the GIFs back into the repo -----------------------------------
 cp "$REC"/*.gif "$REPO/demo/clips/"

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -215,6 +215,34 @@ Step 1 alone proves integrity; steps 2 and 3 additionally prove the assets were
 built by this repository's release workflow on GitHub Actions, not on someone's
 machine.
 
+### How a release is built
+
+Pushing a `v*` tag runs the release workflow: `meta` (resolve the version) →
+`dependencies` and `build` → `smoke` → `assemble` → `publish`. Third-party
+actions are pinned to a commit SHA, so a moved tag cannot change what runs.
+
+Two of those steps exist to catch a broken release before it exists:
+
+- **`smoke`** unpacks each archive and runs the packaged binary end-to-end on a
+  runner of that platform — Linux, macOS (darwin/arm64) and Windows — through
+  `scripts/smoke-artifact.sh`: version, doctor, export, diff, import, undo,
+  `skill install/init/show`, and a cwd round trip that imports with
+  `--map-cwd-here` and then finds the session again with `--project .`. On POSIX
+  it also covers unicode project paths, a project under `$TMPDIR` (a symlinked
+  path on macOS), file permissions, and relocate + undo.
+- **`dependencies`** does not just build the Gentoo module archive, it unpacks
+  it elsewhere and builds `cct` from it with `GOPROXY=off` and
+  `GOTOOLCHAIN=local`, so an archive that is missing a module fails the release
+  rather than the packager.
+
+The same workflow can be started by hand (**Actions → Release → Run workflow**)
+as a dry run. Everything runs except `publish`, under a version like
+`v0.0.0-dryrun-<sha>`, and the assembled files are uploaded as a workflow
+artifact. That is how changes to the workflow itself get tested without
+consuming a version number. Signing and attestation are skipped by default in a
+dry run because both write to a public transparency log; tick `sign` to exercise
+them (the run then also verifies its own signature with `cosign verify-blob`).
+
 ## Claude Code research
 
 Claude Code support was verified empirically against a live install. The storage

--- a/scripts/smoke-artifact.sh
+++ b/scripts/smoke-artifact.sh
@@ -1,11 +1,21 @@
 #!/usr/bin/env bash
-# Exercise a *packaged* cct binary end-to-end: version -> doctor -> export ->
-# diff -> import -> undo, against throwaway fake homes. Run by the release
-# workflow against each built artifact so a broken binary blocks the release.
+# Exercise a *packaged* cct binary end-to-end against throwaway fake homes, so a
+# broken artifact blocks the release. The release workflow runs it on every
+# platform it can execute natively (Linux, macOS, Windows).
 #
-# It uses only relative paths (never a leading-slash path) so the Windows binary
-# under Git Bash gets the same, un-mangled arguments as on Linux, and it does not
-# change directory so the caller-supplied (relative) binary path stays valid.
+# Sections:
+#   1. portable core   — version, doctor, export, diff, import, undo, skill
+#   2. cwd round trip  — import --map-cwd-here, then find the session again with
+#                        --project . This only passes when the path cct recorded
+#                        is the path it resolves "." to, which is where macOS's
+#                        /var -> /private/var symlink and Windows drive letters
+#                        bite.
+#   3. POSIX extras    — unicode project paths, a project under $TMPDIR, file
+#                        permissions, relocate + undo.
+#
+# The portable parts use only relative paths (never a leading-slash path) so the
+# Windows binary under Git Bash gets the same, un-mangled arguments as on Linux.
+# Sections that need a real absolute path run on POSIX only.
 set -euo pipefail
 
 BIN="${1:-}"
@@ -16,6 +26,13 @@ fi
 chmod +x "$BIN" 2>/dev/null || true
 # A bare filename must be run as ./name; a path with a slash runs as-is.
 case "$BIN" in */*) ;; *) BIN="./$BIN" ;; esac
+# Absolute form, for the sections that change directory. Used on POSIX only,
+# where an absolute path is not rewritten on its way into the binary.
+BINABS="$(cd "$(dirname "$BIN")" && pwd)/$(basename "$BIN")"
+ROOT="$PWD"
+
+posix=1
+case "$(uname -s)" in MINGW* | MSYS* | CYGWIN*) posix=0 ;; esac
 
 work="smoke-work"
 rm -rf "$work"
@@ -33,28 +50,151 @@ EOF
 sess="$dst/sessions/2026/06/13/rollout-2026-06-13T18-22-01-$uuid.jsonl"
 bundle="$work/smoke.codexbundle"
 run() { echo "+ $*"; "$@"; }
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+# write_claude_transcript <home> <cwd> <id> — a minimal Claude Code transcript in
+# the folder Claude derives from the cwd (every character outside [A-Za-z0-9-]
+# becomes a dash).
+write_claude_transcript() {
+  local home="$1" cwd="$2" id="$3" encoded escaped
+  encoded="$(encode_cwd "$cwd")"
+  mkdir -p "$home/projects/$encoded"
+  # The cwd is embedded in JSON, so a backslash has to be escaped.
+  escaped="$(printf '%s' "$cwd" | sed 's/\\/\\\\/g')"
+  cat > "$home/projects/$encoded/$id.jsonl" <<EOF
+{"type":"user","uuid":"$id","sessionId":"$id","cwd":"$escaped","timestamp":"2026-06-13T10:00:00Z","message":{"role":"user","content":"artifact smoke test"}}
+EOF
+}
+
+encode_cwd() { printf '%s' "$1" | LC_ALL=C sed 's/[^A-Za-z0-9-]/-/g'; }
 
 echo "== version =="
 run "$BIN" version
 
 echo "== doctor --json =="
-run "$BIN" doctor --json --codex-home "$src" >/dev/null
+run "$BIN" doctor --json --codex-home "$src" > /dev/null
 
 echo "== export =="
-run "$BIN" export --all --codex-home "$src" -o "$bundle" >/dev/null
-test -f "$bundle" || { echo "FAIL: no bundle written" >&2; exit 1; }
+run "$BIN" export --all --codex-home "$src" -o "$bundle" > /dev/null
+test -f "$bundle" || fail "no bundle written"
 
 echo "== diff (read-only) =="
-run "$BIN" diff "$bundle" --codex-home "$dst" >/dev/null
-test ! -e "$sess" || { echo "FAIL: diff wrote a file (must be read-only)" >&2; exit 1; }
+run "$BIN" diff "$bundle" --codex-home "$dst" > /dev/null
+test ! -e "$sess" || fail "diff wrote a file (must be read-only)"
 
 echo "== import =="
-run "$BIN" import "$bundle" --codex-home "$dst" >/dev/null
-test -f "$sess" || { echo "FAIL: import did not create the session" >&2; exit 1; }
+run "$BIN" import "$bundle" --codex-home "$dst" > /dev/null
+test -f "$sess" || fail "import did not create the session"
 
 echo "== undo =="
-run "$BIN" undo --codex-home "$dst" >/dev/null
-test ! -e "$sess" || { echo "FAIL: undo did not remove the imported session" >&2; exit 1; }
+run "$BIN" undo --codex-home "$dst" > /dev/null
+test ! -e "$sess" || fail "undo did not remove the imported session"
 
-rm -rf "$work"
+echo "== skill install / init / show =="
+claude="$work/claude"
+run "$BIN" skill install --claude-home "$claude" > /dev/null
+skillfile="$claude/skills/cct-session-sync/SKILL.md"
+test -f "$skillfile" || fail "skill install did not write $skillfile"
+grep -q "cct-session-sync" "$skillfile" || fail "the installed skill has no frontmatter name"
+# A second install must be a no-op, not an error.
+run "$BIN" skill install --claude-home "$claude" > /dev/null
+
+proj="$work/proj"
+mkdir -p "$proj"
+run "$BIN" skill init --project "$proj" --repo "https://example.invalid/sessions.git" > /dev/null
+test -f "$proj/.cct/sessions.json" || fail "skill init wrote no reference"
+test -f "$proj/.cct/README.md" || fail "skill init wrote no README"
+run "$BIN" skill show --project "$proj" --json | grep -q "example.invalid" \
+  || fail "skill show did not report the store repo"
+# A reference naming a command-executing transport must stop the command.
+sed 's#https://example.invalid/sessions.git#ext::sh -c evil#' "$proj/.cct/sessions.json" > "$work/ref.json"
+mv "$work/ref.json" "$proj/.cct/sessions.json"
+if "$BIN" skill show --project "$proj" > /dev/null 2>&1; then
+  fail "skill show accepted a remote-helper transport"
+fi
+
+echo "== cwd round trip (import --map-cwd-here, then find it again) =="
+rtproj="$work/rt-proj"
+mkdir -p "$rtproj"
+write_claude_transcript "$work/rt-src" "/original/project" "bbbb2222-3333-4444-5555-666677778888"
+run "$BIN" export --all --tool claude --claude-home "$work/rt-src" -o "$work/rt.codexbundle" > /dev/null
+(
+  cd "$rtproj"
+  ../../"$BIN" import ../rt.codexbundle --claude-home ../rt-claude --merge --map-cwd-here > /dev/null
+  ../../"$BIN" export --tool claude --claude-home ../rt-claude --project . -o ../rt-back.codexbundle > /dev/null
+)
+run "$BIN" inspect "$work/rt-back.codexbundle" | grep -q "bbbb2222" \
+  || fail "a session imported with --map-cwd-here is not found again by --project ."
+
+if [ "$posix" -eq 0 ]; then
+  rm -rf "$work"
+  echo "ARTIFACT SMOKE OK (portable sections; POSIX extras skipped on Windows)"
+  exit 0
+fi
+
+echo "== unicode project path =="
+uniproj="$ROOT/$work/pröjekt-日本語"
+mkdir -p "$uniproj"
+(
+  cd "$uniproj"
+  "$BINABS" import "$ROOT/$work/rt.codexbundle" --claude-home "$ROOT/$work/uni-claude" \
+    --merge --map-cwd-here > /dev/null
+  "$BINABS" export --tool claude --claude-home "$ROOT/$work/uni-claude" --project . \
+    -o "$ROOT/$work/uni-back.codexbundle" > /dev/null
+)
+run "$BIN" inspect "$work/uni-back.codexbundle" | grep -q "bbbb2222" \
+  || fail "a unicode project path did not round trip"
+
+echo "== project under \$TMPDIR (a symlinked path on macOS) =="
+tmpbase="$(mktemp -d)"
+trap 'rm -rf "$tmpbase"' EXIT
+mkdir -p "$tmpbase/proj"
+(
+  cd "$tmpbase/proj"
+  "$BINABS" import "$ROOT/$work/rt.codexbundle" --claude-home "$tmpbase/claude" \
+    --merge --map-cwd-here > /dev/null
+  "$BINABS" export --tool claude --claude-home "$tmpbase/claude" --project . \
+    -o "$tmpbase/back.codexbundle" > /dev/null
+)
+run "$BIN" inspect "$tmpbase/back.codexbundle" | grep -q "bbbb2222" \
+  || fail "a project under \$TMPDIR did not round trip (symlinked path?)"
+
+echo "== file permissions =="
+test -x "$BIN" || fail "the packaged binary is not executable"
+mode() { ls -l "$1" | cut -c1-10; }
+case "$(mode "$bundle")" in
+  ?????w* | ????????w*) fail "the bundle is group- or world-writable: $(mode "$bundle")" ;;
+esac
+run "$BIN" import "$bundle" --codex-home "$dst" > /dev/null
+test -f "$sess" || fail "re-import did not create the session"
+case "$(mode "$sess")" in
+  ?????w* | ????????w*) fail "an imported session is group- or world-writable: $(mode "$sess")" ;;
+esac
+test -r "$sess" || fail "an imported session is not readable"
+test -f "$skillfile" && test ! -x "$skillfile" || fail "the installed skill should not be executable"
+
+echo "== relocate + undo =="
+relid="cccc3333-4444-5555-6666-777788889999"
+oldproj="$ROOT/$work/old-project"
+newproj="$ROOT/$work/new-project"
+mkdir -p "$oldproj" "$newproj"
+relhome="$work/rel-claude"
+write_claude_transcript "$relhome" "$oldproj" "$relid"
+oldfile="$relhome/projects/$(encode_cwd "$oldproj")/$relid.jsonl"
+newfile="$relhome/projects/$(encode_cwd "$newproj")/$relid.jsonl"
+run "$BIN" relocate "$oldproj" "$newproj" --tool claude --claude-home "$relhome" --dry-run > /dev/null
+test -f "$oldfile" || fail "--dry-run moved the transcript"
+run "$BIN" relocate "$oldproj" "$newproj" --tool claude --claude-home "$relhome" > /dev/null
+test -f "$newfile" || fail "relocate did not write the transcript under the new project"
+test ! -f "$oldfile" || fail "relocate left the original transcript in place"
+grep -q "$newproj" "$newfile" || fail "relocate did not rewrite the recorded cwd"
+run "$BIN" undo > /dev/null
+test -f "$oldfile" || fail "undo did not restore the original transcript"
+test ! -f "$newfile" || fail "undo did not remove the relocated copy"
+
+rm -rf "$work" "$tmpbase"
+trap - EXIT
 echo "ARTIFACT SMOKE OK"


### PR DESCRIPTION
## P0 — the release workflow can be rehearsed

It only ran on a `v*` tag, so a change to it could not be tested without spending a version number. It now also runs on `workflow_dispatch` as a dry run, and publishing became its own gated job:

`meta` → `dependencies` + `build` → `smoke` → `assemble` → `publish` *(only when `github.ref` is a real `v*` tag)*

A dry run builds under `v0.0.0-dryrun-<sha>`, runs every check, and uploads the assembled files as a workflow artifact — no GitHub Release. Signing and attestation are skipped unless the `sign` input is ticked, because both write to a public transparency log; when they do run, the signature is verified in place with `cosign verify-blob`.

## P1 — macOS artifact tested natively

`smoke` now includes `darwin/arm64` on `macos-latest`, and `scripts/smoke-artifact.sh` covers what the review asked for:

- `skill install` / `init` / `show`, including a reference with an `ext::` transport, which must be refused
- **cwd round trip**: import with `--map-cwd-here`, then find the same session again with `--project .` — this only passes when the path cct recorded is the path it resolves `.` to
- POSIX extras: unicode project paths, a project under `$TMPDIR` (macOS's `/var` → `/private/var` symlink — the exact trap that broke a test in #17), file permissions (packaged binary executable, nothing group/world-writable), and relocate + undo including the dry-run-writes-nothing case

Verified locally on Linux (full POSIX path) and on Windows/Git Bash (portable sections; the POSIX extras are skipped there by design). macOS is covered by CI only — I cannot run it here.

## P1 — the dependency archive is proven offline

After packaging, the job unpacks it somewhere else and builds `cct` from it with `GOPROXY=off`, `GOSUMDB=off` and `GOTOOLCHAIN=local` (the last one matters: otherwise Go may fetch a toolchain instead of failing), then runs the binary. A missing module now fails the release rather than the packager.

## P2 — hardening

- Third-party actions pinned to commit SHAs, tag kept in a trailing comment.
- The 360-minute timeout replaced by 10–45 minutes per job.
- Each archive is checked for its expected files, a single top-level directory (so unpacking cannot scatter files), an executable binary with mode `-rwxr-xr-x`, and no group- or world-writable entries. Rehearsed locally against a good archive and two deliberately broken ones.
- `assemble` re-verifies `SHA256SUMS.txt` and checks the full expected file set before anything is published.

## The demo clip

The tape and its scenario are here (`demo/recording/16-skill.tape`, the `skill` case in `prep.sh`): install the skill → point the project at a private store → commit the reference → export into the store → clone on a second machine → `import --merge --map-cwd-here` → `cct list`. Synthetic sessions and local bare repositories only.

**The GIF is not rendered.** I ran the scenario end to end by hand and it works, but VHS hangs on this machine before producing frames — including on a one-second test tape, so it is the environment, not the tape. Nothing links to a missing image; the clip can be rendered later with `render 16-skill.tape skill`.

## How to check this PR

The point of P0 is that this is now testable: **Actions → Release → Run workflow** on this branch does a full dry run without creating anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
