### PR TITLE
Track repository clone metrics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,3 +85,16 @@ jobs:
         uses: golang/govulncheck-action@v1
         with:
           go-version-file: go.mod
+
+  traffic-metrics:
+    name: traffic metrics merge
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v7
+
+      - name: Test traffic metrics merge
+        run: python -m unittest discover -s scripts -p 'test_*.py' -v
+
+      - name: Compile traffic metrics scripts
+        run: python -m compileall -q scripts

--- a/.github/workflows/traffic-metrics.yml
+++ b/.github/workflows/traffic-metrics.yml
@@ -1,0 +1,75 @@
+name: Repository traffic metrics
+
+on:
+  schedule:
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: repository-traffic-metrics
+  cancel-in-progress: false
+
+jobs:
+  update:
+    name: Update clone history
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      TRAFFIC_TOKEN: ${{ secrets.CCT_TRAFFIC_TOKEN }}
+    steps:
+      - name: Check out workflow source
+        uses: actions/checkout@v7
+
+      - name: Fetch the 14-day clone window
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -z "$TRAFFIC_TOKEN" ]; then
+            echo "CCT_TRAFFIC_TOKEN is not configured." >&2
+            exit 1
+          fi
+          curl --silent --show-error --fail \
+            --header "Accept: application/vnd.github+json" \
+            --header "Authorization: Bearer $TRAFFIC_TOKEN" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            --output "$RUNNER_TEMP/clones.json" \
+            "https://api.github.com/repos/ahmojo/codex-claude-transfer/traffic/clones?per=day"
+
+      - name: Prepare the metrics branch
+        shell: bash
+        run: |
+          set -euo pipefail
+          metrics_dir="$RUNNER_TEMP/metrics-branch"
+          if git ls-remote --exit-code --heads origin metrics >/dev/null; then
+            git fetch --no-tags origin metrics:refs/remotes/origin/metrics
+            git worktree add --detach "$metrics_dir" refs/remotes/origin/metrics
+          else
+            git worktree add --detach "$metrics_dir" HEAD
+            git -C "$metrics_dir" switch --orphan metrics
+          fi
+          echo "METRICS_DIR=$metrics_dir" >> "$GITHUB_ENV"
+
+      - name: Merge the latest window
+        shell: bash
+        run: |
+          set -euo pipefail
+          python scripts/update_traffic_metrics.py \
+            --input "$RUNNER_TEMP/clones.json" \
+            --output "$METRICS_DIR/metrics/traffic.json"
+
+      - name: Commit changed metrics
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -z "$(git -C "$METRICS_DIR" status --porcelain -- metrics/traffic.json)" ]; then
+            echo "Traffic metrics are unchanged."
+            exit 0
+          fi
+          git -C "$METRICS_DIR" config user.name "github-actions[bot]"
+          git -C "$METRICS_DIR" config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git -C "$METRICS_DIR" add metrics/traffic.json
+          git -C "$METRICS_DIR" commit -m "chore(metrics): update repository traffic [skip ci]"
+          git -C "$METRICS_DIR" push origin HEAD:metrics

--- a/README.md
+++ b/README.md
@@ -198,6 +198,42 @@ synthetic session data only, never a real bundle (see
 - [Roadmap](docs/roadmap.md): shipped features, never-planned features, and
   project notes.
 
+## Repository traffic metrics
+
+The daily `Repository traffic metrics` workflow stores a public snapshot at
+`metrics/traffic.json` on the separate `metrics` branch. It records GitHub's
+14-day clone totals and merges the daily counts into an idempotent history.
+The cumulative clone count is complete only from `tracked_since`; GitHub does
+not expose older clone traffic. Daily unique-cloner counts are retained for
+auditability, but they are never summed into an all-time unique value.
+
+The workflow needs one repository secret named `CCT_TRAFFIC_TOKEN`. Create it
+once as follows:
+
+1. Open GitHub **Settings → Developer settings → Personal access tokens →
+   Fine-grained tokens** and choose **Generate new token**.
+2. Select the `ahmojo` resource owner, choose **Only select repositories**,
+   and select only `ahmojo/codex-claude-transfer`.
+3. Under **Repository permissions**, set **Administration** to
+   **Read-only**. Do not grant write access or access to other repositories.
+4. Generate the token and copy it immediately. GitHub shows it only once.
+5. In `ahmojo/codex-claude-transfer`, open **Settings → Secrets and
+   variables → Actions → New repository secret**.
+6. Name the secret exactly `CCT_TRAFFIC_TOKEN`, paste the token, and save it.
+7. Run **Actions → Repository traffic metrics → Run workflow** once. The normal
+   `GITHUB_TOKEN` writes only the generated file to the `metrics` branch.
+
+The token is sent only to GitHub's protected traffic endpoint. It is never
+written to the metrics file, commits, workflow logs, or a browser response.
+The generated file is publicly available at:
+
+```text
+https://raw.githubusercontent.com/ahmojo/codex-claude-transfer/metrics/metrics/traffic.json
+```
+
+Clone traffic can include automated access from CI systems, scanners, bots, and
+other services. No attempt is made to estimate or subtract that traffic.
+
 ## Contributing
 
 PRs welcome. Keep changes small, preserve the no-cloud / no-SQLite-writes

--- a/scripts/test_update_traffic_metrics.py
+++ b/scripts/test_update_traffic_metrics.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import copy
+import unittest
+from datetime import datetime, timedelta, timezone
+
+from update_traffic_metrics import merge_metrics
+
+
+NOW = datetime(2026, 8, 7, 3, 17, tzinfo=timezone.utc)
+
+
+def payload(count, uniques, *days):
+    return {
+        "count": count,
+        "uniques": uniques,
+        "clones": [
+            {"timestamp": f"{day}T00:00:00Z", "count": clones, "uniques": unique}
+            for day, clones, unique in days
+        ],
+    }
+
+
+class MergeTrafficMetricsTests(unittest.TestCase):
+    def test_overlapping_windows_are_idempotent(self):
+        first = merge_metrics(
+            None,
+            payload(
+                5,
+                3,
+                ("2026-08-05", 2, 2),
+                ("2026-08-06", 3, 1),
+            ),
+            updated_at=NOW,
+        )
+        second = merge_metrics(
+            first,
+            payload(
+                5,
+                3,
+                ("2026-08-05", 2, 2),
+                ("2026-08-06", 3, 1),
+            ),
+            updated_at=NOW + timedelta(hours=1),
+        )
+        self.assertEqual(second, first)
+
+    def test_existing_day_is_replaced_not_added_twice(self):
+        first = merge_metrics(
+            None,
+            payload(2, 1, ("2026-08-05", 2, 1)),
+            updated_at=NOW,
+        )
+        second = merge_metrics(
+            first,
+            payload(4, 2, ("2026-08-05", 4, 2)),
+            updated_at=NOW,
+        )
+        self.assertEqual(second["days"]["2026-08-05"]["clones"], 4)
+        self.assertEqual(second["tracked_total_clones"], 4)
+
+    def test_total_is_sum_of_all_stored_daily_clone_counts(self):
+        first = merge_metrics(
+            None,
+            payload(3, 2, ("2026-07-20", 3, 2)),
+            updated_at=NOW,
+        )
+        second = merge_metrics(
+            first,
+            payload(
+                7,
+                4,
+                ("2026-08-05", 2, 1),
+                ("2026-08-06", 5, 3),
+            ),
+            updated_at=NOW,
+        )
+        self.assertEqual(second["tracked_since"], "2026-07-20")
+        self.assertEqual(second["tracked_total_clones"], 10)
+        self.assertEqual(list(second["days"]), sorted(second["days"]))
+
+    def test_top_level_window_values_come_directly_from_api(self):
+        result = merge_metrics(
+            None,
+            payload(99, 42, ("2026-08-06", 3, 2)),
+            updated_at=NOW,
+        )
+        self.assertEqual(result["clones_14d"], 99)
+        self.assertEqual(result["unique_cloners_14d"], 42)
+
+    def test_does_not_calculate_all_time_unique_cloners(self):
+        result = merge_metrics(
+            None,
+            payload(
+                8,
+                5,
+                ("2026-08-05", 4, 3),
+                ("2026-08-06", 4, 3),
+            ),
+            updated_at=NOW,
+        )
+        self.assertNotIn("tracked_total_unique_cloners", result)
+        self.assertNotIn("all_time_unique_cloners", result)
+        self.assertEqual(result["unique_cloners_14d"], 5)
+
+    def test_same_api_date_uses_latest_value(self):
+        result = merge_metrics(
+            None,
+            payload(
+                4,
+                2,
+                ("2026-08-06", 2, 1),
+                ("2026-08-06", 4, 2),
+            ),
+            updated_at=NOW,
+        )
+        self.assertEqual(result["days"]["2026-08-06"]["clones"], 4)
+        self.assertEqual(result["tracked_total_clones"], 4)
+
+    def test_invalid_api_payload_does_not_replace_existing_metrics(self):
+        existing = merge_metrics(
+            None,
+            payload(2, 1, ("2026-08-05", 2, 1)),
+            updated_at=NOW,
+        )
+        snapshot = copy.deepcopy(existing)
+
+        with self.assertRaises(ValueError):
+            merge_metrics(
+                existing,
+                {"count": 0, "uniques": 0, "clones": "invalid"},
+                updated_at=NOW,
+            )
+
+        self.assertEqual(existing, snapshot)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/update_traffic_metrics.py
+++ b/scripts/update_traffic_metrics.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Merge GitHub's overlapping 14-day clone windows into a stable history."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import tempfile
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any
+
+REPO = "ahmojo/codex-claude-transfer"
+SCHEMA_VERSION = 1
+
+
+class MetricsError(ValueError):
+    """Raised when an input document cannot be trusted."""
+
+
+def non_negative_int(value: Any, field: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise MetricsError(f"{field} must be a non-negative integer")
+    return value
+
+
+def timestamp_day(value: Any) -> str:
+    if not isinstance(value, str):
+        raise MetricsError("clone timestamp must be a string")
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise MetricsError(f"invalid clone timestamp: {value}") from exc
+    if parsed.tzinfo is None:
+        raise MetricsError("clone timestamp must include a timezone")
+    return parsed.astimezone(timezone.utc).date().isoformat()
+
+
+def validate_existing(existing: dict[str, Any] | None) -> dict[str, dict[str, int]]:
+    if existing is None:
+        return {}
+    if not isinstance(existing, dict):
+        raise MetricsError("existing metrics must be a JSON object")
+    if existing.get("schema_version") != SCHEMA_VERSION:
+        raise MetricsError("existing metrics use an unsupported schema")
+    if existing.get("repo") != REPO:
+        raise MetricsError("existing metrics belong to a different repository")
+    raw_days = existing.get("days")
+    if not isinstance(raw_days, dict):
+        raise MetricsError("existing metrics days must be an object")
+
+    days: dict[str, dict[str, int]] = {}
+    for day_key, values in raw_days.items():
+        try:
+            normalized_day = date.fromisoformat(day_key).isoformat()
+        except (TypeError, ValueError) as exc:
+            raise MetricsError(f"invalid stored day: {day_key}") from exc
+        if normalized_day != day_key or not isinstance(values, dict):
+            raise MetricsError(f"invalid stored metrics for {day_key}")
+        days[day_key] = {
+            "clones": non_negative_int(values.get("clones"), f"{day_key}.clones"),
+            "unique_cloners": non_negative_int(
+                values.get("unique_cloners"), f"{day_key}.unique_cloners"
+            ),
+        }
+    return days
+
+
+def merge_metrics(
+    existing: dict[str, Any] | None,
+    api_payload: dict[str, Any],
+    *,
+    updated_at: datetime | None = None,
+) -> dict[str, Any]:
+    """Replace overlapping days and recompute the cumulative clone count."""
+    if not isinstance(api_payload, dict):
+        raise MetricsError("GitHub traffic response must be a JSON object")
+    clones_14d = non_negative_int(api_payload.get("count"), "count")
+    unique_cloners_14d = non_negative_int(api_payload.get("uniques"), "uniques")
+    api_days = api_payload.get("clones")
+    if not isinstance(api_days, list):
+        raise MetricsError("clones must be a list")
+
+    days = validate_existing(existing)
+    for entry in api_days:
+        if not isinstance(entry, dict):
+            raise MetricsError("each clone day must be an object")
+        day_key = timestamp_day(entry.get("timestamp"))
+        days[day_key] = {
+            "clones": non_negative_int(entry.get("count"), f"{day_key}.count"),
+            "unique_cloners": non_negative_int(
+                entry.get("uniques"), f"{day_key}.uniques"
+            ),
+        }
+
+    now = updated_at or datetime.now(timezone.utc)
+    if now.tzinfo is None:
+        raise MetricsError("updated_at must include a timezone")
+    now = now.astimezone(timezone.utc)
+    sorted_days = dict(sorted(days.items()))
+    tracked_since = min(sorted_days) if sorted_days else now.date().isoformat()
+
+    result = {
+        "schema_version": SCHEMA_VERSION,
+        "repo": REPO,
+        "tracked_since": tracked_since,
+        "updated_at": now.isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "clones_14d": clones_14d,
+        "unique_cloners_14d": unique_cloners_14d,
+        "tracked_total_clones": sum(day["clones"] for day in sorted_days.values()),
+        "days": sorted_days,
+    }
+    if isinstance(existing, dict):
+        previous_semantics = {
+            key: value for key, value in existing.items() if key != "updated_at"
+        }
+        current_semantics = {
+            key: value for key, value in result.items() if key != "updated_at"
+        }
+        if previous_semantics == current_semantics and isinstance(
+            existing.get("updated_at"), str
+        ):
+            result["updated_at"] = existing["updated_at"]
+    return result
+
+
+def read_json(path: Path, *, required: bool) -> dict[str, Any] | None:
+    if not path.exists():
+        if required:
+            raise MetricsError(f"missing input file: {path}")
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise MetricsError(f"cannot read valid JSON from {path}") from exc
+    if not isinstance(data, dict):
+        raise MetricsError(f"{path} must contain a JSON object")
+    return data
+
+
+def write_json_atomic(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    rendered = json.dumps(data, indent=2, ensure_ascii=False) + "\n"
+    descriptor, temp_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=path.parent
+    )
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8", newline="\n") as handle:
+            handle.write(rendered)
+        os.replace(temp_name, path)
+    except Exception:
+        try:
+            os.unlink(temp_name)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    merged = merge_metrics(
+        read_json(args.output, required=False),
+        read_json(args.input, required=True) or {},
+    )
+    write_json_atomic(args.output, merged)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a daily, persistent repository clone history for the portfolio's transparent usage metrics.

## What changed

- Adds a scheduled 03:17 UTC and manually dispatchable traffic workflow.
- Reads GitHub's protected daily clone endpoint only with `CCT_TRAFFIC_TOKEN`.
- Writes the generated `metrics/traffic.json` snapshot to a separate `metrics` branch using the normal `GITHUB_TOKEN`.
- Replaces overlapping dates instead of adding them twice, sorts dates, and recomputes cumulative clones from stored daily clone counts.
- Preserves the API's top-level 14-day clone and unique-source values directly.
- Avoids unnecessary commits when an identical window is fetched again.
- Documents the least-privilege fine-grained PAT setup and the public raw-file URL.
- Adds standard-library unit tests and a CI job; no new dependencies.

## Semantics

`tracked_total_clones` is complete only from `tracked_since`. Daily unique-source values are retained but never summed into an all-time unique value. Clone traffic may include CI, bots, scanners, and other automation; no estimate or subtraction is performed.

## Validation

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `python -m unittest discover -s scripts -p "test_*.py" -v` — 7 passed
- [x] `python -m compileall -q scripts`
- [x] Workflow YAML parsed successfully
- [x] `git diff --check`

## Required after merge

Create the repository-scoped, Administration read-only fine-grained PAT described in the README, save it as `CCT_TRAFFIC_TOKEN`, then run the workflow once to create the `metrics` branch and initial snapshot.