### PR TITLE
Store daily usage metric snapshots

### DIFF
--- a/.github/workflows/traffic-metrics.yml
+++ b/.github/workflows/traffic-metrics.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   update:
-    name: Update clone history
+    name: Update usage history
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
@@ -52,10 +52,12 @@ jobs:
           fi
           echo "METRICS_DIR=$metrics_dir" >> "$GITHUB_ENV"
 
-      - name: Merge the latest window
+      - name: Merge the latest window and snapshot downloads
         shell: bash
         run: |
           set -euo pipefail
+          # The script reads public release metadata without a token. The
+          # protected token remains scoped to the traffic request above.
           python scripts/update_traffic_metrics.py \
             --input "$RUNNER_TEMP/clones.json" \
             --output "$METRICS_DIR/metrics/traffic.json"

--- a/README.md
+++ b/README.md
@@ -203,6 +203,10 @@ synthetic session data only, never a real bundle (see
 The daily `Repository traffic metrics` workflow stores a public snapshot at
 `metrics/traffic.json` on the separate `metrics` branch. It records GitHub's
 14-day clone totals and merges the daily counts into an idempotent history.
+It also records the cumulative download count of installable release binaries
+and one daily snapshot of the displayed metrics. The current release total
+still covers every published release; download deltas and charts are complete
+only from the first stored daily snapshot.
 The cumulative clone count is complete only from `tracked_since`; GitHub does
 not expose older clone traffic. Daily unique-cloner counts are retained for
 auditability, but they are never summed into an all-time unique value.

--- a/scripts/test_update_traffic_metrics.py
+++ b/scripts/test_update_traffic_metrics.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 import copy
+import io
+import json
 import unittest
 from datetime import datetime, timedelta, timezone
+from urllib.parse import parse_qs, urlparse
 
-from update_traffic_metrics import merge_metrics
+from update_traffic_metrics import fetch_release_downloads, merge_metrics
 
 
 NOW = datetime(2026, 8, 7, 3, 17, tzinfo=timezone.utc)
@@ -133,6 +136,121 @@ class MergeTrafficMetricsTests(unittest.TestCase):
             )
 
         self.assertEqual(existing, snapshot)
+
+    def test_daily_snapshots_overwrite_the_same_date(self):
+        first = merge_metrics(
+            None,
+            payload(2, 1, ("2026-08-06", 2, 1)),
+            release_downloads=10,
+            updated_at=NOW,
+        )
+        second = merge_metrics(
+            first,
+            payload(4, 2, ("2026-08-06", 4, 2)),
+            release_downloads=13,
+            updated_at=NOW + timedelta(hours=1),
+        )
+
+        self.assertEqual(list(second["snapshots"]), ["2026-08-07"])
+        self.assertEqual(
+            second["snapshots"]["2026-08-07"],
+            {
+                "release_downloads": 13,
+                "clones_14d": 4,
+                "unique_cloners_14d": 2,
+                "tracked_total_clones": 4,
+            },
+        )
+
+    def test_failed_release_refresh_preserves_known_download_total(self):
+        first = merge_metrics(
+            None,
+            payload(2, 1, ("2026-08-06", 2, 1)),
+            release_downloads=10,
+            updated_at=NOW,
+        )
+        second = merge_metrics(
+            first,
+            payload(2, 1, ("2026-08-06", 2, 1)),
+            release_downloads=None,
+            updated_at=NOW + timedelta(hours=1),
+        )
+
+        self.assertEqual(second["release_downloads"], 10)
+        self.assertEqual(
+            second["snapshots"]["2026-08-07"]["release_downloads"], 10
+        )
+
+    def test_snapshots_never_add_unique_sources_across_days(self):
+        result = merge_metrics(
+            None,
+            payload(8, 5, ("2026-08-06", 8, 5)),
+            release_downloads=20,
+            updated_at=NOW,
+        )
+
+        self.assertNotIn("tracked_total_unique_cloners", result)
+        self.assertNotIn("all_time_unique_cloners", result)
+        self.assertEqual(
+            result["snapshots"]["2026-08-07"]["unique_cloners_14d"], 5
+        )
+
+
+def release(*assets, draft=False):
+    return {
+        "draft": draft,
+        "assets": [
+            {"name": name, "download_count": count} for name, count in assets
+        ],
+    }
+
+
+class ReleaseDownloadSnapshotTests(unittest.TestCase):
+    @staticmethod
+    def opener_for_pages(pages, requested_pages=None):
+        def open_url(request, timeout):
+            page = int(parse_qs(urlparse(request.full_url).query)["page"][0])
+            if requested_pages is not None:
+                requested_pages.append(page)
+            body = json.dumps(pages.get(page, [])).encode("utf-8")
+            return io.BytesIO(body)
+
+        return open_url
+
+    def test_counts_only_current_and_historical_platform_binaries(self):
+        pages = {
+            1: [
+                release(
+                    ("cct_v1.8.0_windows_amd64.tar.gz", 4),
+                    ("cct_v1.8.0_darwin_arm64.tar.gz", 7),
+                    ("codex-sync_v0.1.13_linux_amd64.tar.gz", 11),
+                    ("SHA256SUMS.txt", 100),
+                    ("SHA256SUMS.txt.sigstore.json", 100),
+                    ("cct_v1.8.0_sbom.spdx.json", 100),
+                    ("codex-claude-transfer-1.8.0-deps.tar.xz", 100),
+                ),
+                release(("cct_v1.9.0_linux_amd64.tar.gz", 50), draft=True),
+            ]
+        }
+
+        self.assertEqual(
+            fetch_release_downloads(self.opener_for_pages(pages)), 22
+        )
+
+    def test_release_fetch_paginates_after_100_releases(self):
+        requested_pages = []
+        pages = {
+            1: [release()] * 100,
+            2: [release(("cct_v2.0.0_linux_arm64.zip", 9))],
+        }
+
+        self.assertEqual(
+            fetch_release_downloads(
+                self.opener_for_pages(pages, requested_pages)
+            ),
+            9,
+        )
+        self.assertEqual(requested_pages, [1, 2])
 
 
 if __name__ == "__main__":

--- a/scripts/update_traffic_metrics.py
+++ b/scripts/update_traffic_metrics.py
@@ -6,13 +6,28 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
+import sys
 import tempfile
 from datetime import date, datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
+from urllib.request import Request, urlopen
 
 REPO = "ahmojo/codex-claude-transfer"
 SCHEMA_VERSION = 1
+RELEASES_URL = f"https://api.github.com/repos/{REPO}/releases"
+SNAPSHOT_FIELDS = (
+    "release_downloads",
+    "clones_14d",
+    "unique_cloners_14d",
+    "tracked_total_clones",
+)
+BINARY_ASSET_RE = re.compile(
+    r"^(?:cct|codex-sync)_v[^_]+_(?:linux|darwin|windows)_"
+    r"(?:amd64|arm64)\.(?:tar\.gz|zip)$",
+    re.IGNORECASE,
+)
 
 
 class MetricsError(ValueError):
@@ -37,9 +52,21 @@ def timestamp_day(value: Any) -> str:
     return parsed.astimezone(timezone.utc).date().isoformat()
 
 
-def validate_existing(existing: dict[str, Any] | None) -> dict[str, dict[str, int]]:
+def validate_day_key(day_key: Any, field: str) -> str:
+    try:
+        normalized_day = date.fromisoformat(day_key).isoformat()
+    except (TypeError, ValueError) as exc:
+        raise MetricsError(f"invalid {field}: {day_key}") from exc
+    if normalized_day != day_key:
+        raise MetricsError(f"invalid {field}: {day_key}")
+    return normalized_day
+
+
+def validate_existing(
+    existing: dict[str, Any] | None,
+) -> tuple[dict[str, dict[str, int]], dict[str, dict[str, int]]]:
     if existing is None:
-        return {}
+        return {}, {}
     if not isinstance(existing, dict):
         raise MetricsError("existing metrics must be a JSON object")
     if existing.get("schema_version") != SCHEMA_VERSION:
@@ -52,11 +79,8 @@ def validate_existing(existing: dict[str, Any] | None) -> dict[str, dict[str, in
 
     days: dict[str, dict[str, int]] = {}
     for day_key, values in raw_days.items():
-        try:
-            normalized_day = date.fromisoformat(day_key).isoformat()
-        except (TypeError, ValueError) as exc:
-            raise MetricsError(f"invalid stored day: {day_key}") from exc
-        if normalized_day != day_key or not isinstance(values, dict):
+        validate_day_key(day_key, "stored day")
+        if not isinstance(values, dict):
             raise MetricsError(f"invalid stored metrics for {day_key}")
         days[day_key] = {
             "clones": non_negative_int(values.get("clones"), f"{day_key}.clones"),
@@ -64,13 +88,68 @@ def validate_existing(existing: dict[str, Any] | None) -> dict[str, dict[str, in
                 values.get("unique_cloners"), f"{day_key}.unique_cloners"
             ),
         }
-    return days
+    raw_snapshots = existing.get("snapshots", {})
+    if not isinstance(raw_snapshots, dict):
+        raise MetricsError("existing metrics snapshots must be an object")
+    snapshots: dict[str, dict[str, int]] = {}
+    for day_key, values in raw_snapshots.items():
+        validate_day_key(day_key, "snapshot day")
+        if not isinstance(values, dict):
+            raise MetricsError(f"invalid snapshot metrics for {day_key}")
+        snapshot: dict[str, int] = {}
+        for field in SNAPSHOT_FIELDS:
+            if field in values:
+                snapshot[field] = non_negative_int(
+                    values[field], f"snapshots.{day_key}.{field}"
+                )
+        if not snapshot:
+            raise MetricsError(f"snapshot {day_key} has no supported metrics")
+        snapshots[day_key] = snapshot
+    return days, snapshots
+
+
+def fetch_release_downloads(
+    open_url: Callable[..., Any] = urlopen,
+) -> int:
+    """Count installable binaries across every published GitHub release."""
+    total = 0
+    page = 1
+    while True:
+        request = Request(
+            f"{RELEASES_URL}?per_page=100&page={page}",
+            headers={
+                "Accept": "application/vnd.github+json",
+                "User-Agent": "cct-traffic-metrics/1.0",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+        )
+        with open_url(request, timeout=15) as response:
+            releases = json.load(response)
+        if not isinstance(releases, list):
+            raise MetricsError("GitHub releases response must be a JSON array")
+        for release in releases:
+            if not isinstance(release, dict) or release.get("draft"):
+                continue
+            assets = release.get("assets", [])
+            if not isinstance(assets, list):
+                continue
+            for asset in assets:
+                if not isinstance(asset, dict):
+                    continue
+                if BINARY_ASSET_RE.fullmatch(str(asset.get("name", ""))):
+                    total += non_negative_int(
+                        asset.get("download_count"), "asset.download_count"
+                    )
+        if len(releases) < 100:
+            return total
+        page += 1
 
 
 def merge_metrics(
     existing: dict[str, Any] | None,
     api_payload: dict[str, Any],
     *,
+    release_downloads: int | None = None,
     updated_at: datetime | None = None,
 ) -> dict[str, Any]:
     """Replace overlapping days and recompute the cumulative clone count."""
@@ -82,7 +161,11 @@ def merge_metrics(
     if not isinstance(api_days, list):
         raise MetricsError("clones must be a list")
 
-    days = validate_existing(existing)
+    if release_downloads is not None:
+        release_downloads = non_negative_int(
+            release_downloads, "release_downloads"
+        )
+    days, snapshots = validate_existing(existing)
     for entry in api_days:
         if not isinstance(entry, dict):
             raise MetricsError("each clone day must be an object")
@@ -100,6 +183,23 @@ def merge_metrics(
     now = now.astimezone(timezone.utc)
     sorted_days = dict(sorted(days.items()))
     tracked_since = min(sorted_days) if sorted_days else now.date().isoformat()
+    tracked_total_clones = sum(
+        day["clones"] for day in sorted_days.values()
+    )
+    snapshot_day = now.date().isoformat()
+    snapshot = {
+        "clones_14d": clones_14d,
+        "unique_cloners_14d": unique_cloners_14d,
+        "tracked_total_clones": tracked_total_clones,
+    }
+    if release_downloads is not None:
+        snapshot["release_downloads"] = release_downloads
+    elif "release_downloads" in snapshots.get(snapshot_day, {}):
+        snapshot["release_downloads"] = snapshots[snapshot_day][
+            "release_downloads"
+        ]
+    snapshots[snapshot_day] = snapshot
+    sorted_snapshots = dict(sorted(snapshots.items()))
 
     result = {
         "schema_version": SCHEMA_VERSION,
@@ -108,9 +208,18 @@ def merge_metrics(
         "updated_at": now.isoformat(timespec="seconds").replace("+00:00", "Z"),
         "clones_14d": clones_14d,
         "unique_cloners_14d": unique_cloners_14d,
-        "tracked_total_clones": sum(day["clones"] for day in sorted_days.values()),
+        "tracked_total_clones": tracked_total_clones,
         "days": sorted_days,
+        "snapshots": sorted_snapshots,
     }
+    if release_downloads is not None:
+        result["release_downloads"] = release_downloads
+    elif isinstance(existing, dict) and isinstance(
+        existing.get("release_downloads"), int
+    ):
+        result["release_downloads"] = non_negative_int(
+            existing["release_downloads"], "release_downloads"
+        )
     if isinstance(existing, dict):
         previous_semantics = {
             key: value for key, value in existing.items() if key != "updated_at"
@@ -162,9 +271,18 @@ def main() -> int:
     parser.add_argument("--input", type=Path, required=True)
     parser.add_argument("--output", type=Path, required=True)
     args = parser.parse_args()
+    try:
+        release_downloads = fetch_release_downloads()
+    except Exception as exc:
+        release_downloads = None
+        print(
+            f"release download snapshot unavailable: {exc}",
+            file=sys.stderr,
+        )
     merged = merge_metrics(
         read_json(args.output, required=False),
         read_json(args.input, required=True) or {},
+        release_downloads=release_downloads,
     )
     write_json_atomic(args.output, merged)
     return 0


### PR DESCRIPTION
## Summary

Extends the repository traffic workflow with stable daily snapshots used for one-day deltas and historical charts in the portfolio.

## What changed

- Records release-download and clone-traffic snapshots once per UTC day.
- Replaces the current day idempotently instead of double-counting reruns.
- Keeps chronological history with a bounded retention window.
- Adds paginated release-asset download counting for supported platform binaries only.
- Adds tests for snapshot updates, release pagination, filtering, and API failures.
- No new dependencies.

## Tests

- 12 Python metric-update tests passed.
- go test ./... passed.
- go vet ./... passed.
- go build ./cmd/cct passed.

## Notes

Clone-source uniqueness remains limited to GitHub's last 14 days. The workflow never calculates an all-time unique clone-source value.