### PR TITLE
Warn before Claude Code's cleanup deletes transcripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to codex-claude-transfer are documented here.
 
+## [Unreleased]
+
+### Added
+- **`cct doctor --tool claude` warns before Claude Code deletes your
+  transcripts.** Claude removes session files older than `cleanupPeriodDays`
+  (30 by default) silently — no prompt, no trash — and users have lost hundreds
+  of transcripts to it, including with an explicit long period set
+  ([anthropics/claude-code#41458](https://github.com/anthropics/claude-code/issues/41458),
+  [#85466](https://github.com/anthropics/claude-code/issues/85466)). doctor now
+  reads that one setting, projects it onto the transcripts on disk, and reports
+  what is already deletable or falls out of the window within 14 days — naming
+  the first date and the exact `cct export --all --tool claude` command to
+  archive them. cct cannot prevent the cleanup and does not try; it makes it
+  visible while there is still time to act. Nothing but the retention number is
+  read from `settings.json`, which also holds API keys.
+
 ## [1.9.0] - 2026-08-09
 
 ### Added

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -9,7 +9,7 @@ Use this page when you need exact commands and flags. For guided workflows, see
 | ------- | ----------- |
 | `cct app` | Launch the local browser UI. It binds to loopback only and uploads nothing. |
 | `cct ui` | Interactive terminal wizard; builds and runs the commands below. |
-| `cct doctor` | Read-only health check: agent home, session counts, missing cwd, and optional tool status. Use `--tool` to pick Codex or Claude Code. |
+| `cct doctor` | Read-only health check: agent home, session counts, missing cwd, and optional tool status. Use `--tool` to pick Codex or Claude Code. For Claude Code it also reads `cleanupPeriodDays` from `settings.json` and warns which transcripts Claude's own cleanup is about to delete. |
 | `cct list` | List discovered sessions with preview, thread id, cwd, source, and updated time. |
 | `cct search <query>` | Full-text search across session conversation text. Supports `--regex`, `--case-sensitive`, `--project`, `--since`, and `--json`. |
 | `cct scan` | Check sessions for likely secrets before sharing or syncing. Read-only; values are masked. |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -233,6 +233,37 @@ One caveat worth knowing: each save commits a full new copy of the bundle, and
 git cannot delta compressed archives, so the repo grows with every commit. If
 that becomes a problem, export a window instead: `--since 30d`.
 
+### Know before Claude Code deletes your transcripts
+
+Claude Code removes session files older than `cleanupPeriodDays` from
+`~/.claude/settings.json` — **30 days when you never set it** — and it does so
+silently: no prompt, no trash. People have lost hundreds of transcripts that way
+([#85466](https://github.com/anthropics/claude-code/issues/85466),
+[#41458](https://github.com/anthropics/claude-code/issues/41458)).
+
+`cct doctor --tool claude` now reads that setting and projects it onto the
+transcripts actually on disk:
+
+```bash
+cct doctor --tool claude
+# warning: 12 transcript(s) fall out of Claude Code's cleanup window
+# (cleanupPeriodDays=30 from settings.json) within 14 days, the first on
+# 2026-08-27; archive them with `cct export --all --tool claude -o claude-archive.codexbundle`
+```
+
+Then the archive is the one command it names:
+
+```bash
+cct export --all --tool claude -o claude-archive.codexbundle
+```
+
+Two honest limits. cct cannot stop the cleanup — it only tells you what is next,
+early enough to act; keeping the sessions is what the export is for. And the
+projection uses each transcript's modification time, which is what an age-based
+cleanup goes by, so a file cct itself re-dated (see `repair-times`) is judged by
+its corrected time. cct reads nothing from `settings.json` except that one
+number: the same file holds API keys, which are none of cct's business.
+
 ### Take a project's memory to the other machine
 
 Claude Code keeps what it has learned about a project in

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -6,6 +6,7 @@ package doctor
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/ahmojo/codex-claude-transfer/internal/claudehome"
 	"github.com/ahmojo/codex-claude-transfer/internal/claudesessions"
@@ -13,6 +14,7 @@ import (
 	"github.com/ahmojo/codex-claude-transfer/internal/crypt"
 	"github.com/ahmojo/codex-claude-transfer/internal/git"
 	"github.com/ahmojo/codex-claude-transfer/internal/repair"
+	"github.com/ahmojo/codex-claude-transfer/internal/retention"
 	"github.com/ahmojo/codex-claude-transfer/internal/sessions"
 	"github.com/ahmojo/codex-claude-transfer/internal/zstdcli"
 )
@@ -126,6 +128,8 @@ func RunClaude(home claudehome.Home) Report {
 		r.warn(fmt.Sprintf("%d transcript file(s) have a modification time ahead of their content (imported by an older cct); run `cct repair-times --tool claude` to fix the open-lag", stale))
 	}
 
+	r.checkClaudeRetention(home, scan.Sessions)
+
 	// Claude-relevant optional tools (git for handoff, age for encryption; zstd
 	// is Codex-only — Claude Code does not compress transcripts).
 	for _, t := range []struct {
@@ -145,6 +149,44 @@ func RunClaude(home claudehome.Home) Report {
 
 	r.ok("~/.claude.json and the Claude cloud are never modified")
 	return r
+}
+
+// RetentionWarnWithin is how far ahead doctor looks for transcripts about to
+// fall out of Claude Code's retention window. Two weeks is long enough to
+// archive them without nagging about every session every day.
+const RetentionWarnWithin = 14 * 24 * time.Hour
+
+// checkClaudeRetention reports what Claude Code's own cleanup is about to
+// delete. Claude removes transcripts older than `cleanupPeriodDays` silently,
+// which is how people lose hundreds of sessions without noticing; cct cannot
+// prevent that, so the least it can do is say which ones are next, while there
+// is still time to export them.
+func (r *Report) checkClaudeRetention(home claudehome.Home, list []sessions.Session) {
+	policy, err := retention.LoadPolicy(home.Root)
+	if err != nil {
+		r.warn(fmt.Sprintf("cannot read Claude Code's cleanup setting: %v", err))
+		return
+	}
+	rep := retention.Assess(list, policy, time.Now(), RetentionWarnWithin)
+
+	source := fmt.Sprintf("its default of %d days", policy.Days)
+	if policy.Configured {
+		source = fmt.Sprintf("cleanupPeriodDays=%d from settings.json", policy.Days)
+	}
+
+	switch {
+	case len(rep.Expired) > 0:
+		r.warn(fmt.Sprintf("%d transcript(s) are already past Claude Code's cleanup window (%s) and can be deleted at any time; archive them with `cct export --all --tool claude -o claude-archive.codexbundle`",
+			len(rep.Expired), source))
+	case len(rep.Soon) > 0:
+		r.warn(fmt.Sprintf("%d transcript(s) fall out of Claude Code's cleanup window (%s) within %d days, the first on %s; archive them with `cct export --all --tool claude -o claude-archive.codexbundle`",
+			len(rep.Soon), source, int(RetentionWarnWithin.Hours()/24), rep.NextDeadline.Format("2006-01-02")))
+	case !policy.Configured && len(list) > 0:
+		r.info(fmt.Sprintf("Claude Code deletes transcripts older than %d days (its default; settings.json sets no cleanupPeriodDays) — nothing is due in the next %d days",
+			policy.Days, int(RetentionWarnWithin.Hours()/24)))
+	default:
+		r.ok(fmt.Sprintf("No transcript is due for Claude Code's cleanup (%s)", source))
+	}
 }
 
 // checkOptionalTools reports which optional external tools are installed. None of

--- a/internal/doctor/retention_test.go
+++ b/internal/doctor/retention_test.go
@@ -1,0 +1,100 @@
+package doctor
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ahmojo/codex-claude-transfer/internal/claudehome"
+)
+
+// claudeHomeWithTranscript builds a fake Claude Code home holding one transcript
+// whose modification time is `ageDays` old, plus an optional settings.json.
+func claudeHomeWithTranscript(t *testing.T, ageDays int, settings string) claudehome.Home {
+	t.Helper()
+	root := filepath.Join(t.TempDir(), "claude")
+	cwd := filepath.Join(root, "proj")
+	dir := filepath.Join(root, claudehome.ProjectsSubdir, claudehome.EncodeCWD(cwd))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	line, _ := json.Marshal(map[string]any{
+		"type": "user", "uuid": "aaaa1111-2222-3333-4444-555566667777",
+		"sessionId": "aaaa1111-2222-3333-4444-555566667777", "cwd": cwd,
+		"timestamp": "2026-06-13T10:00:00Z",
+		"message":   map[string]any{"role": "user", "content": "hello"},
+	})
+	path := filepath.Join(dir, "aaaa1111-2222-3333-4444-555566667777.jsonl")
+	if err := os.WriteFile(path, append(line, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	old := time.Now().AddDate(0, 0, -ageDays)
+	if err := os.Chtimes(path, old, old); err != nil {
+		t.Fatal(err)
+	}
+	if settings != "" {
+		if err := os.WriteFile(filepath.Join(root, "settings.json"), []byte(settings), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return claudehome.Home{Root: root, ProjectsDir: filepath.Join(root, claudehome.ProjectsSubdir), Source: "flag"}
+}
+
+func messages(r Report) string {
+	var b strings.Builder
+	for _, c := range r.Checks {
+		b.WriteString(c.Message)
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+// The case the GitHub reports describe: no cleanupPeriodDays set, so the 30-day
+// default silently applies and old transcripts are already deletable.
+func TestDoctorWarnsAboutExpiredTranscripts(t *testing.T) {
+	home := claudeHomeWithTranscript(t, 45, "")
+	got := messages(RunClaude(home))
+	if !strings.Contains(got, "already past Claude Code's cleanup window") {
+		t.Fatalf("no warning about expired transcripts:\n%s", got)
+	}
+	if !strings.Contains(got, "its default of 30 days") {
+		t.Errorf("the warning does not say the default is in force:\n%s", got)
+	}
+	if !strings.Contains(got, "cct export --all --tool claude") {
+		t.Errorf("the warning does not name the archive command:\n%s", got)
+	}
+}
+
+func TestDoctorWarnsBeforeTheDeadline(t *testing.T) {
+	home := claudeHomeWithTranscript(t, 25, `{"cleanupPeriodDays": 30}`)
+	got := messages(RunClaude(home))
+	if !strings.Contains(got, "within 14 days") {
+		t.Fatalf("no upcoming-deadline warning:\n%s", got)
+	}
+	if !strings.Contains(got, "cleanupPeriodDays=30 from settings.json") {
+		t.Errorf("the warning does not cite the configured setting:\n%s", got)
+	}
+}
+
+// Someone who set a long retention deliberately should hear nothing alarming.
+func TestDoctorQuietUnderALongRetention(t *testing.T) {
+	home := claudeHomeWithTranscript(t, 400, `{"cleanupPeriodDays": 3650}`)
+	got := messages(RunClaude(home))
+	if strings.Contains(got, "cleanup window") && strings.Contains(got, "archive them") {
+		t.Fatalf("a 10-year retention produced a deletion warning:\n%s", got)
+	}
+	if !strings.Contains(got, "No transcript is due for Claude Code's cleanup") {
+		t.Errorf("no reassuring line:\n%s", got)
+	}
+}
+
+func TestDoctorReportsUnreadableSettings(t *testing.T) {
+	home := claudeHomeWithTranscript(t, 5, `{oops`)
+	got := messages(RunClaude(home))
+	if !strings.Contains(got, "cannot read Claude Code's cleanup setting") {
+		t.Fatalf("a broken settings.json was passed over silently:\n%s", got)
+	}
+}

--- a/internal/retention/retention.go
+++ b/internal/retention/retention.go
@@ -1,0 +1,166 @@
+// Package retention answers one question about a Claude Code home: which of its
+// transcripts is Claude Code's own cleanup about to delete?
+//
+// Claude Code removes session files older than `cleanupPeriodDays` (30 by
+// default) from ~/.claude/settings.json. The deletion is silent — no prompt, no
+// trash — and users have reported losing hundreds of transcripts to it,
+// including one case where an explicit `cleanupPeriodDays: 99999` was ignored
+// (anthropics/claude-code#41458, #85466, #86280). cct cannot stop that cleanup
+// and does not try: it reads the setting, projects it onto the transcripts that
+// are actually on disk, and says what is about to go, early enough to archive it.
+//
+// Everything here is read-only. The package never writes to the Claude home, and
+// it deliberately reads nothing from settings.json except the retention number:
+// that file also holds API keys and environment values that are none of cct's
+// business.
+package retention
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"github.com/ahmojo/codex-claude-transfer/internal/sessions"
+)
+
+// SettingsFileName is the Claude Code settings file inside the home.
+const SettingsFileName = "settings.json"
+
+// DefaultDays is the cleanup period Claude Code applies when settings.json does
+// not set one. It is the documented default, and the value most reports of
+// unexpected deletion were running under.
+const DefaultDays = 30
+
+// MaxSettingsBytes caps how much of settings.json is read. The file is small;
+// the cap keeps a corrupt or hostile file from being pulled into memory whole.
+const MaxSettingsBytes = 1 << 20
+
+// Policy is the retention rule cct resolved for a Claude Code home.
+type Policy struct {
+	// Days is the retention period in days.
+	Days int
+	// Configured reports whether settings.json set it explicitly. When false,
+	// Days is DefaultDays and the user may not know a cleanup is happening.
+	Configured bool
+	// SettingsPath is the file consulted, whether or not it existed.
+	SettingsPath string
+}
+
+// Cutoff is the instant a transcript must be newer than to survive.
+func (p Policy) Cutoff(now time.Time) time.Time {
+	return now.AddDate(0, 0, -p.Days)
+}
+
+// LoadPolicy reads the retention setting from a Claude Code home. A missing or
+// unreadable settings.json is not an error: Claude Code applies its default in
+// that case, and so does cct. A settings.json that exists but cannot be parsed
+// is reported, because then cct cannot tell which rule is really in force.
+func LoadPolicy(claudeRoot string) (Policy, error) {
+	p := Policy{Days: DefaultDays, SettingsPath: filepath.Join(claudeRoot, SettingsFileName)}
+
+	info, err := os.Lstat(p.SettingsPath)
+	switch {
+	case errors.Is(err, os.ErrNotExist):
+		return p, nil
+	case err != nil:
+		return p, nil
+	case !info.Mode().IsRegular():
+		return p, fmt.Errorf("%s is not a regular file", p.SettingsPath)
+	case info.Size() > MaxSettingsBytes:
+		return p, fmt.Errorf("%s is unexpectedly large (%d bytes); not parsed", p.SettingsPath, info.Size())
+	}
+
+	data, err := os.ReadFile(p.SettingsPath)
+	if err != nil {
+		return p, nil
+	}
+	// Only the retention number is decoded. settings.json also holds API keys
+	// and environment values, which cct has no reason to read.
+	var parsed struct {
+		CleanupPeriodDays *int `json:"cleanupPeriodDays"`
+	}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		return p, fmt.Errorf("%s is not valid JSON: %w", p.SettingsPath, err)
+	}
+	if parsed.CleanupPeriodDays == nil {
+		return p, nil
+	}
+	if *parsed.CleanupPeriodDays <= 0 {
+		return p, fmt.Errorf("%s sets cleanupPeriodDays to %d; cct cannot tell what that means for deletion",
+			p.SettingsPath, *parsed.CleanupPeriodDays)
+	}
+	p.Days = *parsed.CleanupPeriodDays
+	p.Configured = true
+	return p, nil
+}
+
+// AtRisk is one transcript the cleanup is about to remove (or already may have).
+type AtRisk struct {
+	ThreadID string
+	Path     string
+	CWD      string
+	// Deadline is when this transcript falls outside the retention window. It is
+	// in the past for transcripts already eligible for deletion.
+	Deadline time.Time
+	// DaysLeft is the whole days until Deadline, negative once it has passed.
+	DaysLeft int
+}
+
+// Report is the projection of a retention policy onto the transcripts on disk.
+type Report struct {
+	Policy Policy
+	// Expired are transcripts already older than the retention period. Claude
+	// Code may remove them at any time, and may already have removed others.
+	Expired []AtRisk
+	// Soon are transcripts that fall out of the window within the warning
+	// horizon passed to Assess.
+	Soon []AtRisk
+	// Total is how many transcripts were considered.
+	Total int
+	// NextDeadline is the earliest upcoming deadline among Soon, zero when none.
+	NextDeadline time.Time
+}
+
+// Any reports whether anything is expired or about to expire.
+func (r Report) Any() bool { return len(r.Expired) > 0 || len(r.Soon) > 0 }
+
+// Assess projects a policy onto scanned sessions. A session's last modification
+// time is what the cleanup goes by, so that is what this compares — cct does not
+// re-date anything. Sessions are returned oldest-first, so the caller can name
+// the most urgent one without sorting again.
+func Assess(list []sessions.Session, policy Policy, now time.Time, warnWithin time.Duration) Report {
+	rep := Report{Policy: policy, Total: len(list)}
+	cutoff := policy.Cutoff(now)
+	horizon := now.Add(warnWithin)
+
+	for _, s := range list {
+		if s.ModTime.IsZero() {
+			continue
+		}
+		deadline := s.ModTime.AddDate(0, 0, policy.Days)
+		item := AtRisk{
+			ThreadID: s.ThreadID,
+			Path:     s.Path,
+			CWD:      s.CWD,
+			Deadline: deadline,
+			DaysLeft: int(deadline.Sub(now).Hours() / 24),
+		}
+		switch {
+		case s.ModTime.Before(cutoff):
+			rep.Expired = append(rep.Expired, item)
+		case deadline.Before(horizon):
+			rep.Soon = append(rep.Soon, item)
+		}
+	}
+
+	sort.Slice(rep.Expired, func(i, j int) bool { return rep.Expired[i].Deadline.Before(rep.Expired[j].Deadline) })
+	sort.Slice(rep.Soon, func(i, j int) bool { return rep.Soon[i].Deadline.Before(rep.Soon[j].Deadline) })
+	if len(rep.Soon) > 0 {
+		rep.NextDeadline = rep.Soon[0].Deadline
+	}
+	return rep
+}

--- a/internal/retention/retention_test.go
+++ b/internal/retention/retention_test.go
@@ -1,0 +1,128 @@
+package retention
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/ahmojo/codex-claude-transfer/internal/sessions"
+)
+
+func writeSettings(t *testing.T, root, content string) {
+	t.Helper()
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, SettingsFileName), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// A home without settings.json is the case most reports of surprise deletion
+// were in: the default applies and the user never chose it.
+func TestLoadPolicyDefaultsWhenUnset(t *testing.T) {
+	root := t.TempDir()
+	p, err := LoadPolicy(root)
+	if err != nil {
+		t.Fatalf("missing settings.json must not be an error: %v", err)
+	}
+	if p.Days != DefaultDays || p.Configured {
+		t.Fatalf("policy = %+v, want the %d-day default and Configured=false", p, DefaultDays)
+	}
+
+	writeSettings(t, root, `{"model":"opus","env":{"FOO":"bar"}}`)
+	if p, err = LoadPolicy(root); err != nil || p.Days != DefaultDays || p.Configured {
+		t.Fatalf("settings without the key: policy = %+v err=%v", p, err)
+	}
+}
+
+func TestLoadPolicyReadsTheSetting(t *testing.T) {
+	root := t.TempDir()
+	// A realistic file: the retention number sits among values cct must ignore.
+	writeSettings(t, root, `{"cleanupPeriodDays": 3650, "env": {"ANTHROPIC_API_KEY": "sk-secret"}}`)
+	p, err := LoadPolicy(root)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if p.Days != 3650 || !p.Configured {
+		t.Fatalf("policy = %+v, want 3650 days, Configured=true", p)
+	}
+	if filepath.Base(p.SettingsPath) != SettingsFileName {
+		t.Errorf("SettingsPath = %q", p.SettingsPath)
+	}
+}
+
+// A file cct cannot parse means cct cannot tell which rule is in force, and
+// saying nothing would be worse than saying so.
+func TestLoadPolicyReportsUnusableSettings(t *testing.T) {
+	root := t.TempDir()
+	writeSettings(t, root, `{not json`)
+	if _, err := LoadPolicy(root); err == nil {
+		t.Error("invalid JSON was accepted")
+	}
+	writeSettings(t, root, `{"cleanupPeriodDays": 0}`)
+	if _, err := LoadPolicy(root); err == nil {
+		t.Error("a zero retention period was accepted")
+	}
+	writeSettings(t, root, `{"cleanupPeriodDays": -5}`)
+	if _, err := LoadPolicy(root); err == nil {
+		t.Error("a negative retention period was accepted")
+	}
+}
+
+func TestAssessSplitsExpiredFromSoon(t *testing.T) {
+	now := time.Date(2026, 8, 13, 12, 0, 0, 0, time.UTC)
+	policy := Policy{Days: 30, Configured: true}
+	age := func(days int) time.Time { return now.AddDate(0, 0, -days) }
+
+	list := []sessions.Session{
+		{ThreadID: "gone", ModTime: age(40)},        // 10 days past the window
+		{ThreadID: "edge", ModTime: age(31)},        // just past it
+		{ThreadID: "soon", ModTime: age(25)},        // 5 days left
+		{ThreadID: "later", ModTime: age(5)},        // 25 days left
+		{ThreadID: "undated", ModTime: time.Time{}}, // no mtime: not guessed at
+	}
+
+	rep := Assess(list, policy, now, 14*24*time.Hour)
+	if rep.Total != 5 {
+		t.Fatalf("Total = %d", rep.Total)
+	}
+	if len(rep.Expired) != 2 || rep.Expired[0].ThreadID != "gone" {
+		t.Fatalf("expired = %+v, want gone then edge (oldest first)", rep.Expired)
+	}
+	if len(rep.Soon) != 1 || rep.Soon[0].ThreadID != "soon" {
+		t.Fatalf("soon = %+v, want just 'soon'", rep.Soon)
+	}
+	if rep.Soon[0].DaysLeft != 5 {
+		t.Errorf("DaysLeft = %d, want 5", rep.Soon[0].DaysLeft)
+	}
+	if want := age(25).AddDate(0, 0, 30); !rep.NextDeadline.Equal(want) {
+		t.Errorf("NextDeadline = %v, want %v", rep.NextDeadline, want)
+	}
+	if !rep.Any() {
+		t.Error("Any() = false with expired and soon items")
+	}
+}
+
+// A long retention period is the whole point of setting one: nothing should be
+// reported as at risk.
+func TestAssessQuietUnderALongPolicy(t *testing.T) {
+	now := time.Now()
+	policy := Policy{Days: 3650, Configured: true}
+	list := []sessions.Session{
+		{ThreadID: "old", ModTime: now.AddDate(0, 0, -400)},
+		{ThreadID: "new", ModTime: now},
+	}
+	rep := Assess(list, policy, now, 14*24*time.Hour)
+	if rep.Any() {
+		t.Fatalf("a 10-year policy reported risk: %+v", rep)
+	}
+}
+
+func TestCutoff(t *testing.T) {
+	now := time.Date(2026, 8, 13, 0, 0, 0, 0, time.UTC)
+	if got := (Policy{Days: 30}).Cutoff(now); !got.Equal(time.Date(2026, 7, 14, 0, 0, 0, 0, time.UTC)) {
+		t.Fatalf("Cutoff = %v", got)
+	}
+}


### PR DESCRIPTION
The top finding from the v2.0.0 research round, and the only one that involves actual data loss.

## The problem

Claude Code removes session files older than `cleanupPeriodDays` (30 when unset) with no prompt and no trash:

- [#85466](https://github.com/anthropics/claude-code/issues/85466) - "Default 30-day cleanupPeriodDays silently hard-deleted ~950 session transcripts (no warning, no trash)"
- [#41458](https://github.com/anthropics/claude-code/issues/41458) (4 reactions, 19 comments) - "cleanupPeriodDays: 99999 ignored - 490 sessions silently deleted despite explicit setting"
- [#86280](https://github.com/anthropics/claude-code/issues/86280) - all Cowork projects lost, cleanup named as one cause
- [#79435](https://github.com/anthropics/claude-code/issues/79435) - asks Anthropic to prompt for the setting during onboarding

A tool whose whole purpose is keeping this history should see it coming.

## What this adds

`cct doctor --tool claude` reads that one setting, projects it onto the transcripts on disk, and reports:

```
[warn] 1 transcript(s) are already past Claude Code's cleanup window (its default of 30 days)
       and can be deleted at any time; archive them with
       `cct export --all --tool claude -o claude-archive.codexbundle`
```

Or, before the deadline: `N transcript(s) fall out of ... within 14 days, the first on 2026-08-27`. With a long retention set deliberately it says so and stays quiet: `[ok] No transcript is due for Claude Code's cleanup (cleanupPeriodDays=3650 from settings.json)`. Both verified against a fake home with the packaged binary.

The "one-command archive" is the export command doctor names - I did not add a redundant command for something `cct export` already does.

## Boundaries kept

- **cct does not prevent the cleanup.** It cannot, and pretending otherwise would be worse than silence. It makes the deadline visible while there is still time to export.
- **`internal/retention` is read-only and stdlib-only**, and reads nothing from `settings.json` except the retention number - that file also holds API keys.
- **A settings.json it cannot parse is reported, not guessed at.** Guessing wrong here means telling someone their history is safe when it is not. Same for a non-positive period.
- The projection uses each transcript's modification time, which is what an age-based cleanup goes by.

## Tests

`internal/retention`: default when unset, the setting read out of a realistic file (with an API key next to it, ignored), invalid JSON and non-positive periods refused, expired-vs-soon split with oldest-first ordering and `DaysLeft`, a long policy staying quiet, cutoff arithmetic.

`internal/doctor`: the four doctor outcomes end-to-end against fake homes - already expired (default in force), deadline within 14 days (configured), long retention quiet, unreadable settings surfaced.

`go vet`, `gofmt` and the full suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
